### PR TITLE
FIX: T2w image of MNI template unavailable in Singularity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -213,7 +213,7 @@ WORKDIR /src/
 
 # Precaching atlases
 RUN python -c "from templateflow import api as tfapi; \
-               tfapi.get('MNI152NLin2009cAsym', resolution=[1, 2], suffix='T1w', desc=None); \
+               tfapi.get('MNI152NLin2009cAsym', resolution=[1, 2], suffix=['T1w', 'T2w'], desc=None); \
                tfapi.get('MNI152NLin2009cAsym', resolution=[1, 2], suffix='mask',\
                          desc=['brain', 'head']); \
                tfapi.get('MNI152NLin2009cAsym', resolution=1, suffix='dseg', desc='carpet'); \


### PR DESCRIPTION
Prefetch this image so that MRIQC works more smoothly with Singularity.