### PR TITLE
Make toml config unique, works around #912

### DIFF
--- a/mriqc/cli/run.py
+++ b/mriqc/cli/run.py
@@ -29,6 +29,7 @@ def main():
     import gc
     import os
     import sys
+    from tempfile import mktemp
     from multiprocessing import Manager, Process
 
     from ..utils.bids import write_bidsignore, write_derivative_description
@@ -45,7 +46,9 @@ def main():
     # CRITICAL Save the config to a file. This is necessary because the execution graph
     # is built as a separate process to keep the memory footprint low. The most
     # straightforward way to communicate with the child process is via the filesystem.
-    config_file = config.execution.work_dir / ".mriqc.toml"
+    # The config file name needs to be unique, otherwise multiple mriqc instances
+    # will create write conflicts.
+    config_file = mktemp(dir=config.execution.work_dir, prefix='.mriqc.', suffix='.toml')
     config.to_filename(config_file)
 
     # Set up participant level

--- a/mriqc/config.py
+++ b/mriqc/config.py
@@ -58,7 +58,7 @@ graph is built across processes.
 .. code-block:: Python
 
     from mriqc import config
-    config_file = config.execution.work_dir / '.mriqc.toml'
+    config_file = mktemp(dir=config.execution.work_dir, prefix='.mriqc.', suffix='.toml')
     config.to_filename(config_file)
     # Call build_workflow(config_file, retval) in a subprocess
     with Manager() as mgr:


### PR DESCRIPTION
So instead of locking the config file (across multiple threads, yikes) I decided to just make the config file name unique using `mktemp`, avoiding the write conflict. Should avoid #912, but trashes the work directory a little.