### PR TITLE
Nipype multiproc plugin expects n_procs and not nprocs

### DIFF
--- a/mriqc/config.py
+++ b/mriqc/config.py
@@ -268,7 +268,7 @@ class nipype(_Config):
             "plugin_args": cls.plugin_args,
         }
         if cls.plugin in ("MultiProc", "LegacyMultiProc"):
-            out["plugin_args"]["nprocs"] = int(cls.nprocs)
+            out["plugin_args"]["n_procs"] = int(cls.nprocs)
             if cls.memory_gb:
                 out["plugin_args"]["memory_gb"] = float(cls.memory_gb)
         return out


### PR DESCRIPTION
Fix typo in multiproc configuration.

Nipype [expects `n_procs`](https://github.com/nipy/nipype/blob/master/nipype/pipeline/plugins/multiproc.py#L127) and not `nprocs` here. Explains #931 . Tested with 0.16.1 and monitored thread count with and without patch. Seems to be working.