### PR TITLE
ENH: Update to new niworkflows' API, which adds the crown to the carpetplot

### DIFF
--- a/mriqc/workflows/functional.py
+++ b/mriqc/workflows/functional.py
@@ -392,6 +392,7 @@ def individual_reports(name="ReportsWorkflow"):
 
     """
     from niworkflows.interfaces.plotting import FMRISummary
+    from niworkflows.interfaces.morphology import CrownMask
 
     from mriqc.interfaces import PlotMosaic, PlotSpikes, Spikes
     from mriqc.interfaces.reports import IndividualReport
@@ -420,7 +421,7 @@ def individual_reports(name="ReportsWorkflow"):
                 "in_spikes",
                 "in_fft",
                 "mni_report",
-                "ica_report",
+                "ica_report"
             ]
         ),
         name="inputnode",
@@ -445,6 +446,9 @@ def individual_reports(name="ReportsWorkflow"):
         mem_gb=mem_gb * 2.5,
     )
 
+    # Generate crown mask
+    crown_mask = pe.Node(CrownMask(), name="crown_mask")
+
     bigplot = pe.Node(FMRISummary(), name="BigPlot", mem_gb=mem_gb * 3.5)
 
     # fmt: off
@@ -452,12 +456,14 @@ def individual_reports(name="ReportsWorkflow"):
         (inputnode, spikes_bg, [("in_ras", "in_file")]),
         (inputnode, spmask, [("in_ras", "in_file")]),
         (inputnode, bigplot, [("hmc_epi", "in_func"),
-                              ("brainmask", "in_mask"),
                               ("hmc_fd", "fd"),
                               ("fd_thres", "fd_thres"),
                               ("in_dvars", "dvars"),
                               ("epi_parc", "in_segm"),
                               ("outliers", "outliers")]),
+        (inputnode, crown_mask, [("brainmask", "in_brainmask")]),
+        (inputnode, crown_mask, [("epi_parc", "in_segm")]),
+        (crown_mask, bigplot, [("out_mask", "in_crown")]),
         (spikes_bg, bigplot, [("out_tsz", "in_spikes_bg")]),
         (spmask, spikes_bg, [("out_file", "in_mask")]),
     ])

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     nibabel >= 3.0.1,<4.0
     nilearn >= 0.2.6, != 0.5.0, != 0.5.1
     nipype ~= 1.4
-    niworkflows ~= 1.4.0
+    niworkflows @ git+https://github.com/celprov/niworkflows.git@enh/royal-carpetplot
     numpy
     pandas >= 0.21.0
     pybids >= 0.12.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     nibabel >= 3.0.1,<4.0
     nilearn >= 0.2.6, != 0.5.0, != 0.5.1
     nipype ~= 1.4
-    niworkflows @ git+https://github.com/celprov/niworkflows.git@enh/royal-carpetplot
+    niworkflows @ git+https://github.com/nipreps/niworkflows.git@master
     numpy
     pandas >= 0.21.0
     pybids >= 0.12.1


### PR DESCRIPTION
This pull request implements the integration of the voxels at the edge of the brain (also called crown) in the carpet plot.
To do so, the interface to compute the crown mask has been integrated in the functional workflow.

IMPORTANT ! : This piece of code depends on the change in the niworkflow repositories commited under the pull request nipreps/niworkflows#651.