### PR TITLE
FIX: preserve WM segments in rodents

### DIFF
--- a/mriqc/interfaces/anatomical.py
+++ b/mriqc/interfaces/anatomical.py
@@ -74,6 +74,7 @@ class StructuralQCInputSpec(BaseInterfaceInputSpec):
     in_fwhm = traits.List(
         traits.Float, mandatory=True, desc="smoothness estimated with AFNI"
     )
+    human = traits.Bool(True, usedefault=True, desc="human workflow")
 
 
 class StructuralQCOutputSpec(TraitedSpec):
@@ -109,7 +110,12 @@ class StructuralQC(SimpleInterface):
 
     def _run_interface(self, runtime):  # pylint: disable=R0914,E1101
         imnii = nb.load(self.inputs.in_noinu)
-        erode = np.all(np.array(imnii.header.get_zooms()[:3], dtype=np.float32) < 1.9)
+        if self.inputs.human:
+            erode = np.all(
+                np.array(imnii.header.get_zooms()[:3], dtype=np.float32) < 1.9
+            )
+        else:
+            erode = False
 
         # Load image corrected for INU
         inudata = np.nan_to_num(imnii.get_data())
@@ -359,6 +365,7 @@ class HarmonizeInputSpec(BaseInterfaceInputSpec):
     )
     wm_mask = File(exists=True, mandatory=True, desc="white-matter mask")
     erodemsk = traits.Bool(True, usedefault=True, desc="erode mask")
+    thresh = traits.Float(0.9, usedefault=True, desc="WM probability threshold")
 
 
 class HarmonizeOutputSpec(TraitedSpec):

--- a/mriqc/interfaces/anatomical.py
+++ b/mriqc/interfaces/anatomical.py
@@ -110,12 +110,9 @@ class StructuralQC(SimpleInterface):
 
     def _run_interface(self, runtime):  # pylint: disable=R0914,E1101
         imnii = nb.load(self.inputs.in_noinu)
-        if self.inputs.human:
-            erode = np.all(
-                np.array(imnii.header.get_zooms()[:3], dtype=np.float32) < 1.9
-            )
-        else:
-            erode = False
+        erode = np.all(
+            np.array(imnii.header.get_zooms()[:3], dtype=np.float32) < 1.9
+        ) if self.inputs.human else False
 
         # Load image corrected for INU
         inudata = np.nan_to_num(imnii.get_data())

--- a/mriqc/workflows/anatomical.py
+++ b/mriqc/workflows/anatomical.py
@@ -391,12 +391,18 @@ def compute_iqms(name="ComputeIQMs"):
 
     # Harmonize
     homog = pe.Node(Harmonize(), name="harmonize")
+    if config.workflow.species.lower() != "human":
+        homog.inputs.erodemsk = False
+        homog.inputs.thresh = 0.8
 
     # Mortamet's QI2
     getqi2 = pe.Node(ComputeQI2(), name="ComputeQI2")
 
     # Compute python-coded measures
-    measures = pe.Node(StructuralQC(), "measures")
+    measures = pe.Node(
+        StructuralQC(human=config.workflow.species.lower() == "human"),
+        "measures"
+    )
 
     # Project MNI segmentation to T1 space
     invt = pe.MapNode(


### PR DESCRIPTION
In rodents, the proportion of WM and CSF are much smaller than in humans, and the spatial distribution of WM in particular is much thinner. Additionally, switching from FAST to Atropos for segmentation (f0dae1a07a05ca5d69c1d305f46c602bb237908f) results in fewer voxels with WM probabilities > 0.9 in some subjects.

Thus, eroding segmentations (WM segments in particular) and high binarising thresholds was generating empty images that caused the summary statistics to fail in a subset of subjects from a large dataset of T2w images. The proposed changes only apply when the `--species` flag is not set to the default `human` so it shouldn't impact most use cases.