### PR TITLE
FIX: Resource profiler was broken with config file

### DIFF
--- a/mriqc/cli/parser.py
+++ b/mriqc/cli/parser.py
@@ -262,7 +262,9 @@ Automated Quality Control and visual reports for Quality Assesment of structural
         help="Do not run the workflow.",
     )
     g_outputs.add_argument(
+        "--resource-monitor",
         "--profile",
+        dest="resource_monitor",
         action="store_true",
         default=False,
         help="Hook up the resource profiler callback to nipype.",


### PR DESCRIPTION
This PR addresses a long-standing problem introduced with the config file. Since MRIQC uses the ``--profiler`` flag and it is not marked up with a ``dest="resource_monitor"`` for argparse, then the resource monitor of Nipype is never enabled.

Resolves: #459.