### PR TITLE
ENH: Revise plugin and workflow initialization

### DIFF
--- a/mriqc/__main__.py
+++ b/mriqc/__main__.py
@@ -1,0 +1,32 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+#
+# Copyright 2022 The NiPreps Developers <nipreps@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We support and encourage derived works from this project, please read
+# about our expectations at
+#
+#     https://www.nipreps.org/community/licensing/
+#
+from .cli.run import main
+
+if __name__ == "__main__":
+    import sys
+    from . import __name__ as module
+
+    # `python -m <module>` typically displays the command as __main__.py
+    if "__main__.py" in sys.argv[0]:
+        sys.argv[0] = "%s -m %s" % (sys.executable, module)
+    main()

--- a/mriqc/cli/run.py
+++ b/mriqc/cli/run.py
@@ -37,20 +37,12 @@ def main():
 
     _plugin = config.nipype.get_plugin()
     if config.nipype.plugin in ("MultiProc", "LegacyMultiProc"):
-        from importlib import import_module
-        from multiprocessing import set_start_method
-        from contextlib import suppress
+        import multiprocessing as mp
+        import multiprocessing.forkserver
 
         with suppress(RuntimeError):
-            set_start_method("forkserver")
-
-        Plugin = getattr(
-            import_module(f"nipype.pipeline.plugins.{config.nipype.plugin.lower()}"),
-            f"{config.nipype.plugin}Plugin",
-        )
-        _plugin = {
-            "plugin": Plugin(plugin_args=config.nipype.plugin_args),
-        }
+            mp.set_start_method("forkserver")
+            mp.forkserver.ensure_running()
         gc.collect()
 
     if config.execution.pdb:

--- a/mriqc/cli/run.py
+++ b/mriqc/cli/run.py
@@ -37,6 +37,7 @@ def main():
 
     _plugin = config.nipype.get_plugin()
     if config.nipype.plugin in ("MultiProc", "LegacyMultiProc"):
+        from contextlib import suppress
         import multiprocessing as mp
         import multiprocessing.forkserver
 

--- a/mriqc/cli/run.py
+++ b/mriqc/cli/run.py
@@ -21,7 +21,6 @@
 #     https://www.nipreps.org/community/licensing/
 #
 """Definition of the command line interface's (CLI) entry point."""
-from mriqc import config, messages
 
 
 def main():
@@ -30,13 +29,29 @@ def main():
     import os
     import sys
     from tempfile import mktemp
-    from multiprocessing import Manager, Process
-
-    from ..utils.bids import write_bidsignore, write_derivative_description
-    from .parser import parse_args
+    from mriqc import config, messages
+    from mriqc.cli.parser import parse_args
 
     # Run parser
     parse_args()
+
+    _plugin = config.nipype.get_plugin()
+    if config.nipype.plugin in ("MultiProc", "LegacyMultiProc"):
+        from importlib import import_module
+        from multiprocessing import set_start_method
+        from contextlib import suppress
+
+        with suppress(RuntimeError):
+            set_start_method("forkserver")
+
+        Plugin = getattr(
+            import_module(f"nipype.pipeline.plugins.{config.nipype.plugin.lower()}"),
+            f"{config.nipype.plugin}Plugin",
+        )
+        _plugin = {
+            "plugin": Plugin(plugin_args=config.nipype.plugin_args),
+        }
+        gc.collect()
 
     if config.execution.pdb:
         from mriqc.utils.debug import setup_exceptionhook
@@ -55,6 +70,8 @@ def main():
 
     # Set up participant level
     if "participant" in config.workflow.analysis_level:
+        from mriqc.workflows.core import init_mriqc_wf
+
         start_message = messages.PARTICIPANT_START.format(
             version=config.environment.version,
             bids_dir=config.execution.bids_dir,
@@ -62,42 +79,22 @@ def main():
             analysis_level=config.workflow.analysis_level,
         )
         config.loggers.cli.log(25, start_message)
-        # CRITICAL Call build_workflow(config_file, retval) in a subprocess.
-        # Because Python on Linux does not ever free virtual memory (VM), running the
-        # workflow construction jailed within a process preempts excessive VM buildup.
-        with Manager() as mgr:
-            from .workflow import build_workflow
-
-            retval = mgr.dict()
-            p = Process(target=build_workflow, args=(str(config_file), retval))
-            p.start()
-            p.join()
-
-            mriqc_wf = retval.get("workflow", None)
-            retcode = p.exitcode or retval.get("return_code", 0)
-
-        # CRITICAL Load the config from the file. This is necessary because the ``build_workflow``
-        # function executed constrained in a process may change the config (and thus the global
-        # state of MRIQC).
-        config.load(config_file)
-
-        retcode = retcode or (mriqc_wf is None) * os.EX_SOFTWARE
-        if retcode != 0:
-            sys.exit(retcode)
+        mriqc_wf = init_mriqc_wf()
+        if mriqc_wf is None:
+            sys.exit(os.EX_SOFTWARE)
 
         if mriqc_wf and config.execution.write_graph:
             mriqc_wf.write_graph(graph2use="colored", format="svg", simple_form=True)
-
-        # Clean up master process before running workflow, which may create forks
-        gc.collect()
 
         if not config.execution.dry_run:
             # Warn about submitting measures BEFORE
             if not config.execution.no_sub:
                 config.loggers.cli.warning(config.DSA_MESSAGE)
 
+            # Clean up master process before running workflow, which may create forks
+            gc.collect()
             # run MRIQC
-            mriqc_wf.run(**config.nipype.get_plugin())
+            mriqc_wf.run(**_plugin)
 
             # Warn about submitting measures AFTER
             if not config.execution.no_sub:
@@ -146,6 +143,8 @@ def main():
             raise Exception(messages.GROUP_NO_DATA)
 
         config.loggers.cli.info(messages.GROUP_FINISHED)
+
+    from mriqc.utils.bids import write_bidsignore, write_derivative_description
 
     config.loggers.cli.info(messages.BIDS_META)
     write_derivative_description(config.execution.bids_dir, config.execution.output_dir)

--- a/mriqc/config.py
+++ b/mriqc/config.py
@@ -97,17 +97,7 @@ try:
     # This option is only available with Python 3.8
     from importlib.metadata import version as get_version
 except ImportError:
-
-    def get_version(module_name):
-        """Get version of package without importing it."""
-        from pkg_resources import get_distribution, DistributionNotFound
-
-        try:
-            return get_distribution(module_name).version
-        except DistributionNotFound as err:
-            from importlib.metadata import PackageNotFoundError
-
-            raise PackageNotFoundError from err
+    from importlib_metadata import version as get_version
 
 
 # Ignore annoying warnings

--- a/mriqc/config.py
+++ b/mriqc/config.py
@@ -87,25 +87,33 @@ The :py:mod:`config` is responsible for other conveniency actions.
     :py:class:`~bids.layout.BIDSLayout`, etc.)
 
 """
-from multiprocessing import set_start_method
-from contextlib import suppress
-
-with suppress(RuntimeError):
-    set_start_method("forkserver")
-
-# Defer all custom import for after initializing the forkserver and
-# ignoring the most annoying warnings
-from ._warnings import logging
 import os
 import sys
 from pathlib import Path
 from time import strftime
 from uuid import uuid4
 
-from nipype import __version__ as _nipype_ver
-from templateflow import __version__ as _tf_ver
+try:
+    # This option is only available with Python 3.8
+    from importlib.metadata import version as get_version
+except ImportError:
 
-from mriqc import __version__
+    def get_version(module_name):
+        """Get version of package without importing it."""
+        from pkg_resources import get_distribution, DistributionNotFound
+
+        try:
+            return get_distribution(module_name).version
+        except DistributionNotFound as err:
+            from importlib.metadata import PackageNotFoundError
+
+            raise PackageNotFoundError from err
+
+
+# Ignore annoying warnings
+from mriqc._warnings import logging
+
+__version__ = get_version("mriqc")
 
 # Disable NiPype etelemetry always
 _disable_et = bool(
@@ -254,9 +262,9 @@ class environment(_Config):
     """Linux's kernel virtual memory overcommit policy."""
     overcommit_limit = _oc_limit
     """Linux's kernel virtual memory overcommit limits."""
-    nipype_version = _nipype_ver
+    nipype_version = get_version("nipype")
     """Nipype's current version."""
-    templateflow_version = _tf_ver
+    templateflow_version = get_version("templateflow")
     """The TemplateFlow client version installed."""
     version = __version__
     """*MRIQC*'s version."""
@@ -462,9 +470,7 @@ class execution(_Config):
 
 # These variables are not necessary anymore
 del _exec_env
-del _nipype_ver
 del _templateflow_home
-del _tf_ver
 del _free_mem_at_start
 del _oc_limit
 del _oc_policy
@@ -625,6 +631,7 @@ def dumps():
 def to_filename(filename):
     """Write settings to file."""
     filename = Path(filename)
+    filename.parent.mkdir(exist_ok=True, parents=True)
     filename.write_text(dumps())
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ url = https://github.com/nipreps/mriqc
 [options]
 python_requires = >= 3.7
 install_requires =
+    importlib-metadata; python_version<'3.8'
     jinja2 < 3.1
     markupsafe ~= 2.0.1  # jinja2 imports deprecated function removed in 2.1
     matplotlib


### PR DESCRIPTION
It seems that confining the workflow creation within an isolated process does not meaningfully help with the VM allocation while increasing the complexity horribly.

On the other hand, the config file has been made considerably more lightweight by using importlib metadata to check versions instead of importing packages, and the plugin instance (MultiProc and LegacyMultiProc) are now created at earlier states so workers are initialized with smaller memory fingerprint.