### PR TITLE
ENH: Deprecate ``--start-idx`` / ``--stop-idx``

### DIFF
--- a/mriqc/cli/parser.py
+++ b/mriqc/cli/parser.py
@@ -29,7 +29,8 @@ from mriqc import config
 def _build_parser():
     """Build parser object."""
     import sys
-    from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+    import warnings
+    from argparse import Action, ArgumentDefaultsHelpFormatter, ArgumentParser
     from functools import partial
     from pathlib import Path
     from shutil import which
@@ -37,6 +38,11 @@ def _build_parser():
     from packaging.version import Version
 
     from .version import check_latest, is_flagged
+
+    class DeprecateAction(Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            warnings.warn(f"Argument {option_string} is deprecated and is *ignored*.")
+            delattr(namespace, self.dest)
 
     def _path_exists(path, parser):
         """Ensure a given path exists."""
@@ -379,16 +385,16 @@ not be what you want in, e.g., shared systems like a HPC cluster.""",
     )
     g_func.add_argument(
         "--start-idx",
-        action="store",
+        action=DeprecateAction,
         type=int,
-        help="Initial volume in functional timeseries that should be "
+        help="DEPRECATED Initial volume in functional timeseries that should be "
         "considered for preprocessing.",
     )
     g_func.add_argument(
         "--stop-idx",
-        action="store",
+        action=DeprecateAction,
         type=int,
-        help="Final volume in functional timeseries that should be "
+        help="DEPRECATED Final volume in functional timeseries that should be "
         "considered for preprocessing.",
     )
     g_func.add_argument(

--- a/mriqc/config.py
+++ b/mriqc/config.py
@@ -507,10 +507,6 @@ class workflow(_Config):
     """Run ICA on the raw data and include the components in the individual reports."""
     inputs = None
     """List of files to be processed with MRIQC."""
-    start_idx = None
-    """Initial volume in functional timeseries that should be considered for preprocessing."""
-    stop_idx = None
-    """Final volume in functional timeseries that should be considered for preprocessing."""
     species = "human"
     """Subject species to choose most appropriate template"""
     template_id = "MNI152NLin2009cAsym"

--- a/mriqc/workflows/utils.py
+++ b/mriqc/workflows/utils.py
@@ -32,27 +32,6 @@ def _tofloat(inlist):
         return float(inlist)
 
 
-def fmri_getidx(in_file, start_idx, stop_idx):
-    """Heuristics to set the start and stop indices of fMRI series"""
-    from nibabel import load
-    from nipype.interfaces.base import isdefined
-
-    nvols = load(in_file).shape[3]
-    max_idx = nvols - 1
-
-    if (
-        start_idx is None
-        or not isdefined(start_idx)
-        or start_idx < 0
-        or start_idx > max_idx
-    ):
-        start_idx = 0
-
-    if stop_idx is None or not isdefined(stop_idx) or max_idx < stop_idx < start_idx:
-        stop_idx = max_idx
-    return start_idx, stop_idx
-
-
 def fwhm_dict(fwhm):
     """Convert a list of FWHM into a dictionary"""
     fwhm = [float(f) for f in fwhm]


### PR DESCRIPTION
*MRIQC* is not a preprocessing tool. Therefore, there is no point in offering customizations that, instead, will open up the workflow to greater analytical variability. Instead of adding knobs for users to play with, it is better to make a more complete reporting of outputs (e.g., #992).

This PR disregards both flags from now on.

Resolves: #965.