### PR TITLE
set rat-specific defaults for FD calculations

### DIFF
--- a/mriqc/cli/parser.py
+++ b/mriqc/cli/parser.py
@@ -559,7 +559,7 @@ Please, check out your currently set filters:
         # TODO: add other species once rats are working
         if opts.species.lower() == "rat":
             config.workflow.template_id = "Fischer344"
-            # mean distance from the lateral edge to the center of the brain is
+            # mean distance from the lateral edge to the center of the brain is
             # ~ PA:10 mm, LR:7.5 mm, and IS:5 mm (see DOI: 10.1089/089771503770802853)
             # roll movement is most likely to occur, so set to 7.5 mm
             config.workflow.fd_radius = 7.5 if opts.fd_radius is None else opts.fd_radius

--- a/mriqc/cli/parser.py
+++ b/mriqc/cli/parser.py
@@ -559,6 +559,10 @@ Please, check out your currently set filters:
         # TODO: add other species once rats are working
         if opts.species.lower() == "rat":
             config.workflow.template_id = "Fischer344"
+            # mean distance from the lateral edge to the center of the brain is
+            # ~ PA:10 mm, LR:7.5 mm, and IS:5 mm (see DOI: 10.1089/089771503770802853)
+            # roll movement is most likely to occur, so set to 7.5 mm
+            config.workflow.fd_radius = 7.5 if opts.fd_radius is None else opts.fd_radius
             config.workflow.headmask = "NoBET"
             # block uploads for the moment; can be reversed before wider release
             config.execution.no_sub = True

--- a/mriqc/cli/parser.py
+++ b/mriqc/cli/parser.py
@@ -562,7 +562,7 @@ Please, check out your currently set filters:
             # mean distance from the lateral edge to the center of the brain is
             # ~ PA:10 mm, LR:7.5 mm, and IS:5 mm (see DOI: 10.1089/089771503770802853)
             # roll movement is most likely to occur, so set to 7.5 mm
-            config.workflow.fd_radius = 7.5 if opts.fd_radius is None else opts.fd_radius
+            config.workflow.fd_radius = 7.5
             config.workflow.headmask = "NoBET"
             # block uploads for the moment; can be reversed before wider release
             config.execution.no_sub = True


### PR DESCRIPTION
Currently, rotational FD components are calculated as the displacement on the surface of a sphere with a radius of 50 mm, because it:
> is approximately the mean distance from the cerebral cortex to the center of the head
according to Power et al., 2012.

This is obviously not appropriate for rodents, so we would expect rat data to exaggerate the contribution of rotational movement in FD calculations.

The only adjustment (so far) is to adjust the default radius if the species is non-human. This is less trivial for rats than humans, since brains of the former are not spherical. In my experience, roll rotations are more likely to occur if the animal is fixed in place with ear and bite bars, so I set the radius to be half of the average lateral width for 90-day-old rats in Gefen et al. (2004; https://doi.org/10.1089/089771503770802853). This can still be adjusted by changing the defaults on the command line, but it would provide a better default with the `--species rat` flag for minimal user intervention.

I'll try re-running this on some data to see if the default 0.2mm FD is still reasonable in rats given these changes.
@oesteban do you have any insight on why this threshold was chosen? Are there any other parameters you can think of that I should check?
