### PR TITLE
FIX: SynthStrip preprocessing miscalculating new shape after reorientation

### DIFF
--- a/mriqc/synthstrip/cli.py
+++ b/mriqc/synthstrip/cli.py
@@ -211,6 +211,9 @@ def conform(input_nii):
         np.ceil(np.array(target_shape) / 64).astype(int) * 64, 192, 320
     )
 
+    # Ensure shape ordering is LIA too
+    target_shape[2], target_shape[1] = target_shape[1:3]
+
     # Coordinates of center voxel do not change
     input_c = affine @ np.hstack((0.5 * (shape - 1), 1.0))
     target_c = target_affine @ np.hstack((0.5 * (target_shape - 1), 1.0))


### PR DESCRIPTION
The calculation of the new shape within the preprocessing for SynthStrip was done in XYZ coordinates (i.e., extents for each physical axis were estimated and divided by the new 1mm pixel size). However, the new axis sizes did not account for data being stored with IJK -> XZY convention (corresponding to LIA).

This PR accounts for this miscalculation.

Resolves: #999.