### PR TITLE
FIX: orientation of visualisations when `species == "rat"`

### DIFF
--- a/mriqc/workflows/anatomical.py
+++ b/mriqc/workflows/anatomical.py
@@ -533,7 +533,11 @@ def individual_reports(name="ReportsWorkflow"):
     )
 
     mosaic_zoom = pe.Node(
-        PlotMosaic(out_file="plot_anat_mosaic1_zoomed.svg", cmap="Greys_r"),
+        PlotMosaic(
+            out_file="plot_anat_mosaic1_zoomed.svg",
+            cmap="Greys_r",
+            species=config.workflow.species.lower()
+        ),
         name="PlotMosaicZoomed",
     )
 
@@ -542,6 +546,7 @@ def individual_reports(name="ReportsWorkflow"):
             out_file="plot_anat_mosaic2_noise.svg",
             only_noise=True,
             cmap="viridis_r",
+            species=config.workflow.species.lower(),
         ),
         name="PlotMosaicNoise",
     )

--- a/mriqc/workflows/anatomical.py
+++ b/mriqc/workflows/anatomical.py
@@ -584,7 +584,7 @@ def individual_reports(name="ReportsWorkflow"):
 
     plot_segm = pe.Node(
         PlotContours(
-            display_mode="z",
+            display_mode="y" if config.workflow.species.lower() == "rat" else "z",
             levels=[0.5, 1.5, 2.5],
             cut_coords=10,
             colors=["r", "g", "b"],
@@ -594,7 +594,7 @@ def individual_reports(name="ReportsWorkflow"):
 
     plot_bmask = pe.Node(
         PlotContours(
-            display_mode="z",
+            display_mode="y" if config.workflow.species.lower() == "rat" else "z",
             levels=[0.5],
             colors=["r"],
             cut_coords=10,
@@ -604,7 +604,7 @@ def individual_reports(name="ReportsWorkflow"):
     )
     plot_airmask = pe.Node(
         PlotContours(
-            display_mode="x",
+            display_mode="y" if config.workflow.species.lower() == "rat" else "x",
             levels=[0.5],
             colors=["r"],
             cut_coords=6,
@@ -614,7 +614,7 @@ def individual_reports(name="ReportsWorkflow"):
     )
     plot_headmask = pe.Node(
         PlotContours(
-            display_mode="x",
+            display_mode="y" if config.workflow.species.lower() == "rat" else "x",
             levels=[0.5],
             colors=["r"],
             cut_coords=6,
@@ -624,7 +624,7 @@ def individual_reports(name="ReportsWorkflow"):
     )
     plot_artmask = pe.Node(
         PlotContours(
-            display_mode="z",
+            display_mode="y" if config.workflow.species.lower() == "rat" else "z",
             levels=[0.5],
             colors=["r"],
             cut_coords=10,

--- a/mriqc/workflows/functional.py
+++ b/mriqc/workflows/functional.py
@@ -532,7 +532,6 @@ def individual_reports(name="ReportsWorkflow"):
         PlotMosaic(
             out_file="plot_func_mean_mosaic1.svg",
             cmap="Greys_r",
-            species=config.workflow.species.lower(),
         ),
         name="PlotMosaicMean",
     )
@@ -541,7 +540,6 @@ def individual_reports(name="ReportsWorkflow"):
         PlotMosaic(
             out_file="plot_func_stddev_mosaic2_stddev.svg",
             cmap="viridis",
-            species=config.workflow.species.lower(),
         ),
         name="PlotMosaicSD",
     )
@@ -614,7 +612,6 @@ def individual_reports(name="ReportsWorkflow"):
         PlotMosaic(
             out_file="plot_anat_mosaic1_zoomed.svg",
             cmap="Greys_r",
-            species=config.workflow.species.lower(),
         ),
         name="PlotMosaicZoomed",
     )
@@ -624,17 +621,22 @@ def individual_reports(name="ReportsWorkflow"):
             out_file="plot_anat_mosaic2_noise.svg",
             only_noise=True,
             cmap="viridis_r",
-            species=config.workflow.species.lower(),
         ),
         name="PlotMosaicNoise",
     )
+
+    if config.workflow.species.lower() in ("rat", "mouse"):
+        mosaic_mean.inputs.view = ("coronal", "axial")
+        mosaic_stddev.inputs.view = ("coronal", "axial")
+        mosaic_zoom.inputs.view = ("coronal", "axial")
+        mosaic_noise.inputs.view = ("coronal", "axial")
 
     # Verbose-reporting goes here
     from nireports.interfaces import PlotContours
 
     plot_bmask = pe.Node(
         PlotContours(
-            display_mode="y" if config.workflow.species.lower() == "rat" else "z",
+            display_mode="y" if config.workflow.species.lower() in ("rat", "mouse") else "z",
             levels=[0.5],
             colors=["r"],
             cut_coords=10,

--- a/mriqc/workflows/functional.py
+++ b/mriqc/workflows/functional.py
@@ -529,12 +529,20 @@ def individual_reports(name="ReportsWorkflow"):
     # fmt: on
 
     mosaic_mean = pe.Node(
-        PlotMosaic(out_file="plot_func_mean_mosaic1.svg", cmap="Greys_r"),
+        PlotMosaic(
+            out_file="plot_func_mean_mosaic1.svg",
+            cmap="Greys_r",
+            species=config.workflow.species.lower(),
+        ),
         name="PlotMosaicMean",
     )
 
     mosaic_stddev = pe.Node(
-        PlotMosaic(out_file="plot_func_stddev_mosaic2_stddev.svg", cmap="viridis"),
+        PlotMosaic(
+            out_file="plot_func_stddev_mosaic2_stddev.svg",
+            cmap="viridis",
+            species=config.workflow.species.lower(),
+        ),
         name="PlotMosaicSD",
     )
 
@@ -603,7 +611,11 @@ def individual_reports(name="ReportsWorkflow"):
         return workflow
 
     mosaic_zoom = pe.Node(
-        PlotMosaic(out_file="plot_anat_mosaic1_zoomed.svg", cmap="Greys_r"),
+        PlotMosaic(
+            out_file="plot_anat_mosaic1_zoomed.svg",
+            cmap="Greys_r",
+            species=config.workflow.species.lower(),
+        ),
         name="PlotMosaicZoomed",
     )
 
@@ -612,6 +624,7 @@ def individual_reports(name="ReportsWorkflow"):
             out_file="plot_anat_mosaic2_noise.svg",
             only_noise=True,
             cmap="viridis_r",
+            species=config.workflow.species.lower(),
         ),
         name="PlotMosaicNoise",
     )
@@ -621,7 +634,7 @@ def individual_reports(name="ReportsWorkflow"):
 
     plot_bmask = pe.Node(
         PlotContours(
-            display_mode="z",
+            display_mode="y" if config.workflow.species.lower() == "rat" else "z",
             levels=[0.5],
             colors=["r"],
             cut_coords=10,


### PR DESCRIPTION
Usually, rodent brains are viewed in the coronal orientation, as is the convention from physical atlases.

This updates the mosaic viz functions to change the orientation when `species == rat`: coronal becomes the primary axis (instead of axial), while axial becomes the secondary axis (instead of sagittal)

