### PR TITLE
ENH: Add migas telemetry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,6 +305,7 @@ jobs:
       - TZ: "/usr/share/zoneinfo/America/Los_Angeles"
       - TEST_DATA_NAME: "circle-tests"
       - MRIQC_API_DOCKER_IMAGES: "nginx swaggerapi/swagger-ui:latest mongo python:3.6-onbuild dockereve-master_eve:latest"
+      - MIGAS_OPTOUT: "1"
     machine:
       # https://discuss.circleci.com/t/linux-machine-executor-images-2021-april-q2-update/39928
       # upgrade Docker version
@@ -464,6 +465,7 @@ jobs:
       - TZ: "/usr/share/zoneinfo/America/Los_Angeles"
       - TEST_DATA_NAME: "circle-tests"
       - MRIQC_API_DOCKER_IMAGES: "nginx swaggerapi/swagger-ui:latest mongo python:3.6-onbuild dockereve-master_eve:latest"
+      - MIGAS_OPTOUT: "1"
     machine:
       # https://discuss.circleci.com/t/linux-machine-executor-images-2021-april-q2-update/39928
       # upgrade Docker version

--- a/mriqc/cli/parser.py
+++ b/mriqc/cli/parser.py
@@ -346,6 +346,13 @@ not be what you want in, e.g., shared systems like a HPC cluster.""",
         default=False,
         help="Upload will fail if upload is strict.",
     )
+    g_outputs.add_argument(
+        "--notrack",
+        action="store_true",
+        help="Opt-out of sending tracking information of this run to the NiPreps developers. This"
+        " information helps to improve MRIQC and provides an indicator of real world usage "
+        " crucial for obtaining funding.",
+    )
 
     # ANTs options
     g_ants = parser.add_argument_group("Specific settings for ANTs")

--- a/mriqc/cli/workflow.py
+++ b/mriqc/cli/workflow.py
@@ -30,6 +30,8 @@ dictionary (``retval``) to allow isolation using a
 a hard-limited memory-scope.
 """
 
+EXITCODE: int = 1
+
 
 def build_workflow(config_file, retval):
     """Create the Nipype Workflow that supports the whole execution graph."""
@@ -54,10 +56,43 @@ def build_workflow(config_file, retval):
         analysis_level=config.workflow.analysis_level,
     )
     config.loggers.cli.log(25, start_message)
+    if not config.execution.notrack:
+        import atexit
+        from ..utils.telemetry import setup_migas
+
+        atexit.register(migas_exit)
+        setup_migas(init=True)
 
     retval["return_code"] = 1
     retval["workflow"] = None
 
     retval["workflow"] = init_mriqc_wf()
     retval["return_code"] = int(retval["workflow"] is None)
+
+    global EXITCODE
+    EXITCODE = retval["return_code"]
+
     return retval
+
+
+def migas_exit() -> None:
+    """
+    Send a final crumb to the migas server signaling if the run successfully completed
+    This function should be registered with `atexit` to run at termination.
+    """
+    import sys
+    from ..utils.telemetry import send_breadcrumb
+
+    global EXITCODE
+    migas_kwargs = {'status': 'completed'}
+    # `sys` will not have these attributes unless an error has been handled
+    if hasattr(sys, 'last_type'):
+        migas_kwargs = {
+            'status_desc': 'Finished with error(s)',
+            'error_type': sys.last_type,
+            'error_desc': sys.last_value,
+        }
+    elif EXITCODE == 0:
+        migas_kwargs.update({'status': 'completed', 'status_desc': 'Finished without error'})
+
+    send_breadcrumb(**migas_kwargs)

--- a/mriqc/config.py
+++ b/mriqc/config.py
@@ -374,6 +374,8 @@ class execution(_Config):
     """Filter input dataset by MRI type."""
     no_sub = False
     """Turn off submission of anonymized quality metrics to Web API."""
+    notrack = False
+    """Disable the sharing of usage information with developers."""
     output_dir = None
     """Folder where derivatives will be stored."""
     participant_label = None

--- a/mriqc/utils/telemetry.py
+++ b/mriqc/utils/telemetry.py
@@ -1,0 +1,27 @@
+import migas
+
+from .. import __version__, config
+
+
+def setup_migas(init: bool = True) -> None:
+    """
+    Prepare the migas python client to communicate with a migas server.
+    If ``init`` is ``True``, send an initial breadcrumb.
+    """
+    # generate session UUID from generated run UUID
+    session_id = None
+    if config.execution.run_uuid:
+        session_id = config.execution.run_uuid.split('_', 1)[-1]
+
+    migas.setup(session_id=session_id)
+    if init:
+        # send initial status ping
+        send_breadcrumb(status='R', status_desc='workflow start')
+
+
+def send_breadcrumb(**kwargs) -> dict:
+    """
+    Communicate with the migas telemetry server. This requires `migas.setup()` to be called.
+    """
+    res = migas.add_project("nipreps/mriqc", __version__, **kwargs)
+    return res

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     jinja2 < 3.1
     markupsafe ~= 2.0.1  # jinja2 imports deprecated function removed in 2.1
     matplotlib
+    migas
     mriqc-learn
     nibabel >= 3.0.1,<4.0
     nilearn >= 0.5.1


### PR DESCRIPTION
This add `migas` telemetry to the MRIQC workflow, which is enabled by default. A new option `--notrack` can be used to disable monitoring.