### PR TITLE
Use task_id in group reporting

### DIFF
--- a/mriqc/cli/run.py
+++ b/mriqc/cli/run.py
@@ -189,7 +189,9 @@ def main():
         mod_group_reports = []
         for mod in config.execution.modalities or DEFAULT_TYPES:
             output_dir = config.execution.output_dir
-            dataframe, out_tsv = generate_tsv(output_dir, mod)
+            task_id = config.execution.task_id
+            task_id = task_id[0] if task_id else None
+            dataframe, out_tsv = generate_tsv(output_dir, mod, task_id)
             # If there are no iqm.json files, nothing to do.
             if dataframe is None:
                 continue
@@ -202,10 +204,12 @@ def main():
             #     log.info('Predicted QA CSV table for the %s data generated (%s)',
             #                    mod, out_pred)
 
-            out_html = output_dir / f"group_{mod}.html"
+            task = f'_task-{task_id}' if task_id else ''
+            out_html = output_dir / f"group_{mod}{task}.html"
             group_html(
                 out_tsv,
                 mod,
+                task_id,
                 csv_failed=output_dir / f"group_variant-failed_{mod}.csv",
                 out_file=out_html,
             )

--- a/mriqc/data/reports/group.html
+++ b/mriqc/data/reports/group.html
@@ -23,6 +23,9 @@ report</h1>
 <ul class="simple">
 <li>Date and time: {{ timestamp }}.</li>
 <li>MRIQC version: {{ version }}.</li>
+{% if task_id %}
+<li>Task ID: {{ task_id }}</li>
+{% endif %}
 {% if failed %}
 <li><span class="text-warning">Some individual reports failed</span>:
 {% for f in failed %}

--- a/mriqc/reports/group.py
+++ b/mriqc/reports/group.py
@@ -31,7 +31,7 @@ from .. import config
 from ..utils.misc import BIDS_COMP
 
 
-def gen_html(csv_file, mod, csv_failed=None, out_file=None):
+def gen_html(csv_file, mod, task_id=None, csv_failed=None, out_file=None):
     import datetime
     import os.path as op
 
@@ -263,6 +263,7 @@ def gen_html(csv_file, mod, csv_failed=None, out_file=None):
     tpl.generate_conf(
         {
             "modality": mod,
+            "task_id": task_id,
             "timestamp": datetime.datetime.now().strftime("%Y-%m-%d, %H:%M"),
             "version": ver,
             "csv_groups": csv_groups,

--- a/mriqc/utils/misc.py
+++ b/mriqc/utils/misc.py
@@ -171,14 +171,18 @@ def generate_pred(derivatives_dir, output_dir, mod):
     return out_csv
 
 
-def generate_tsv(output_dir, mod):
+def generate_tsv(output_dir, mod, task_id=None):
     """
     Generates a tsv file from all json files in the derivatives directory
     """
 
     # If some were found, generate the CSV file and group report
-    out_tsv = output_dir / ("group_%s.tsv" % mod)
+    out_tsv = f"group_{mod}"
     jsonfiles = list(output_dir.glob("sub-*/**/%s/sub-*_%s.json" % (IMTYPES[mod], mod)))
+    if task_id:
+        jsonfiles = [j for j in jsonfiles if f'task-{task_id}' in str(j)]
+        out_tsv += f"_task-{task_id}"
+    out_tsv = output_dir / f"{out_tsv}.tsv"
     if not jsonfiles:
         return None, out_tsv
 


### PR DESCRIPTION
This is a sort of selfish implementation to solve #812  because we needed it today.

We reuse the task_id argument and filter participant label measurement json files to generate a group report (html) with a a new suffix and a task id in the html template.

Shortcomings:

+ this would get ugly quickly if someone decides to add more than just the task_id filter
+ task_id could have multiple values in theory, but we don't handle that to keep the PR as simple as possible