### PR TITLE
FIX: Resource monitor would not ever start tracking

### DIFF
--- a/mriqc/instrumentation/__main__.py
+++ b/mriqc/instrumentation/__main__.py
@@ -29,4 +29,4 @@ if __name__ == "__main__":
     # `python -m <module>` typically displays the command as __main__.py
     if "__main__.py" in sys.argv[0]:
         sys.argv[0] = "%s -m %s" % (sys.executable, module)
-    ResourceRecorder(pid=sys.argv[1]).start()
+    ResourceRecorder(pid=int(sys.argv[1])).start()


### PR DESCRIPTION
This was likely caused by a change in Python of how `Event()` is initialized.

Clearing the event before entering the loop seems necessary now.

In addition, a more reliable initialization of the logfile pathname is also done here.