### PR TITLE
FIX: Move telemetry atexit into entrypoint func

### DIFF
--- a/mriqc/cli/run.py
+++ b/mriqc/cli/run.py
@@ -21,7 +21,7 @@
 #     https://www.nipreps.org/community/licensing/
 #
 """Definition of the command line interface's (CLI) entry point."""
-
+EXITCODE: int = -1
 
 def main():
     """Entry point for MRIQC's CLI."""
@@ -87,11 +87,18 @@ def main():
             )
             _resmon.start()
 
+        if not config.execution.notrack:
+            from ..utils.telemetry import setup_migas
+
+            setup_migas(init=True)
+            atexit.register(migas_exit)
+
         # CRITICAL Call build_workflow(config_file, retval) in a subprocess.
         # Because Python on Linux does not ever free virtual memory (VM), running the
         # workflow construction jailed within a process preempts excessive VM buildup.
         from multiprocessing import Manager, Process
 
+        global EXITCODE
         with Manager() as mgr:
             from .workflow import build_workflow
 
@@ -101,16 +108,16 @@ def main():
             p.join()
 
             mriqc_wf = retval.get("workflow", None)
-            retcode = p.exitcode or retval.get("return_code", 0)
+            EXITCODE = p.exitcode or retval.get("return_code", 0)
 
         # CRITICAL Load the config from the file. This is necessary because the ``build_workflow``
         # function executed constrained in a process may change the config (and thus the global
         # state of MRIQC).
         config.load(config_file)
 
-        retcode = retcode or (mriqc_wf is None) * os.EX_SOFTWARE
-        if retcode != 0:
-            sys.exit(retcode)
+        EXITCODE = EXITCODE or (mriqc_wf is None) * os.EX_SOFTWARE
+        if EXITCODE != 0:
+            sys.exit(EXITCODE)
 
         # Initialize nipype config
         config.nipype.init()
@@ -226,6 +233,29 @@ def main():
     write_derivative_description(config.execution.bids_dir, config.execution.output_dir)
     write_bidsignore(config.execution.output_dir)
     config.loggers.cli.info(messages.RUN_FINISHED)
+
+def migas_exit() -> None:
+    """
+    Send a final crumb to the migas server signaling if the run successfully completed
+    This function should be registered with `atexit` to run at termination.
+    """
+    import sys
+    from ..utils.telemetry import send_breadcrumb
+
+    global EXITCODE
+    migas_kwargs = {'status': 'C', 'status_desc': 'Success'}
+    # `sys` will not have these attributes unless an error has been handled
+    if hasattr(sys, 'last_type'):
+        migas_kwargs = {
+            'status': 'F',
+            'status_desc': 'Finished with error(s)',
+            'error_type': sys.last_type,
+            'error_desc': sys.last_value,
+        }
+    elif EXITCODE != 0:
+        migas_kwargs.update({'status': 'F', 'status_desc': f'Completed with exitcode {EXITCODE}'})
+
+    send_breadcrumb(**migas_kwargs)
 
 
 if __name__ == "__main__":

--- a/mriqc/cli/run.py
+++ b/mriqc/cli/run.py
@@ -23,6 +23,7 @@
 """Definition of the command line interface's (CLI) entry point."""
 EXITCODE: int = -1
 
+
 def main():
     """Entry point for MRIQC's CLI."""
     import gc
@@ -233,6 +234,7 @@ def main():
     write_derivative_description(config.execution.bids_dir, config.execution.output_dir)
     write_bidsignore(config.execution.output_dir)
     config.loggers.cli.info(messages.RUN_FINISHED)
+
 
 def migas_exit() -> None:
     """

--- a/mriqc/cli/workflow.py
+++ b/mriqc/cli/workflow.py
@@ -30,8 +30,6 @@ dictionary (``retval``) to allow isolation using a
 a hard-limited memory-scope.
 """
 
-EXITCODE: int = 1
-
 
 def build_workflow(config_file, retval):
     """Create the Nipype Workflow that supports the whole execution graph."""
@@ -56,43 +54,10 @@ def build_workflow(config_file, retval):
         analysis_level=config.workflow.analysis_level,
     )
     config.loggers.cli.log(25, start_message)
-    if not config.execution.notrack:
-        import atexit
-        from ..utils.telemetry import setup_migas
-
-        atexit.register(migas_exit)
-        setup_migas(init=True)
 
     retval["return_code"] = 1
     retval["workflow"] = None
 
     retval["workflow"] = init_mriqc_wf()
     retval["return_code"] = int(retval["workflow"] is None)
-
-    global EXITCODE
-    EXITCODE = retval["return_code"]
-
     return retval
-
-
-def migas_exit() -> None:
-    """
-    Send a final crumb to the migas server signaling if the run successfully completed
-    This function should be registered with `atexit` to run at termination.
-    """
-    import sys
-    from ..utils.telemetry import send_breadcrumb
-
-    global EXITCODE
-    migas_kwargs = {'status': 'completed'}
-    # `sys` will not have these attributes unless an error has been handled
-    if hasattr(sys, 'last_type'):
-        migas_kwargs = {
-            'status_desc': 'Finished with error(s)',
-            'error_type': sys.last_type,
-            'error_desc': sys.last_value,
-        }
-    elif EXITCODE == 0:
-        migas_kwargs.update({'status': 'completed', 'status_desc': 'Finished without error'})
-
-    send_breadcrumb(**migas_kwargs)


### PR DESCRIPTION
The final process status is not properly sent to migas, as the exit function is not registered correctly.

This mirrors the logic used in fmriprep.