### PR TITLE
FIX: Address non-empty take from empty axes (anatomical IQMs)

### DIFF
--- a/mriqc/qc/anatomical.py
+++ b/mriqc/qc/anatomical.py
@@ -603,7 +603,7 @@ def summary_stats(img, pvms, airmask=None, erode=True):
 
     output = {}
     for k, lid in labels:
-        mask = np.where(stats_pvms[lid] > 0.85)
+        mask = stats_pvms[lid] > 0.85
         nvox = mask.sum()
 
         if erode and nvox > 2e3:


### PR DESCRIPTION
This patch addresses this problem encountered in some occassions, where the mask on which summary stats are to be calculated is too small.

Fixes: #1048.
Fixes: #868.