### PR TITLE
FIX: Send metadata extraction to workers (functional workflow)

### DIFF
--- a/mriqc/workflows/functional.py
+++ b/mriqc/workflows/functional.py
@@ -364,7 +364,8 @@ def compute_iqms(name="ComputeIQMs"):
     # fmt: on
 
     # Add metadata
-    meta = pe.Node(ReadSidecarJSON(), name="metadata", run_without_submitting=True)
+    meta = pe.Node(ReadSidecarJSON(), name="metadata")
+
     addprov = pe.Node(
         AddProvenance(modality="bold"),
         name="provenance",


### PR DESCRIPTION
The metadata node takes ~50s for large datasets.
In the meantime while we find a better solution (perhaps dropping PyBIDS), it's better to send the metadata node to the workers so execution doesn't get stuck.