### PR TITLE
ENH: Optimize metadata gathering reusing ``BIDSLayout`` db

### DIFF
--- a/mriqc/workflows/anatomical.py
+++ b/mriqc/workflows/anatomical.py
@@ -382,7 +382,9 @@ def compute_iqms(name="ComputeIQMs"):
     )
 
     # Extract metadata
-    meta = pe.Node(ReadSidecarJSON(), name="metadata")
+    meta = pe.Node(ReadSidecarJSON(
+        index_db=config.execution.bids_database_dir
+    ), name="metadata")
 
     # Add provenance
     addprov = pe.Node(AddProvenance(), name="provenance", run_without_submitting=True)

--- a/mriqc/workflows/functional.py
+++ b/mriqc/workflows/functional.py
@@ -364,7 +364,9 @@ def compute_iqms(name="ComputeIQMs"):
     # fmt: on
 
     # Add metadata
-    meta = pe.Node(ReadSidecarJSON(), name="metadata")
+    meta = pe.Node(ReadSidecarJSON(
+        index_db=config.execution.bids_database_dir
+    ), name="metadata")
 
     addprov = pe.Node(
         AddProvenance(modality="bold"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "nipype ~= 1.4",
     "nireports >= 23.0",
     "nitransforms >= 21.0.1",
-    "niworkflows >= 1.7.6",
+    "niworkflows @ git+https://github.com/nipreps/niworkflows.git@master",
     "numpy ~=1.20",
     "pandas ~=1.0",
     "pybids >= 0.15.6",


### PR DESCRIPTION
There's no need to index the BIDS folder repeatedly with each of these interfaces.

Requires: nipreps/niworkflows#788.