### PR TITLE
FIX: BIDS database directory handling

### DIFF
--- a/.circleci/circle_T1w.txt
+++ b/.circleci/circle_T1w.txt
@@ -1,3 +1,5 @@
+.bids_db
+.bids_db/layout_index.sqlite
 .bidsignore
 dataset_description.json
 group_T1w.html

--- a/.circleci/circle_bold.txt
+++ b/.circleci/circle_bold.txt
@@ -1,3 +1,5 @@
+.bids_db
+.bids_db/layout_index.sqlite
 .bidsignore
 dataset_description.json
 group_bold.html

--- a/mriqc/tests/test_config.py
+++ b/mriqc/tests/test_config.py
@@ -69,6 +69,7 @@ def test_bids_indexing_manifest(tmp_path, testdata_path, testcase):
 
     reload(config)
 
+    config.execution.output_dir = Path(tmp_path) / "out"
     config.execution.bids_dir = _expand_bids(
         tmp_path,
         testdata_path,


### PR DESCRIPTION
Optimize the BIDS database handling by generating it in the output folder. Users can reset it by just deleting it (or the full folder, if necessary).

Several processes can be managed robustly by generating the index cache on a temporary folder with a unique name.