### PR TITLE
fix: PlotMosaic expects lists, not tuples

### DIFF
--- a/mriqc/workflows/anatomical/output.py
+++ b/mriqc/workflows/anatomical/output.py
@@ -78,8 +78,8 @@ def init_anat_report_wf(name: str = "anat_report_wf"):
         name="PlotMosaicNoise",
     )
     if config.workflow.species.lower() in ("rat", "mouse"):
-        mosaic_zoom.inputs.view = ("coronal", "axial")
-        mosaic_noise.inputs.view = ("coronal", "axial")
+        mosaic_zoom.inputs.view = ["coronal", "axial"]
+        mosaic_noise.inputs.view = ["coronal", "axial"]
 
     ds_report_zoomed = pe.Node(
         DerivativesDataSink(

--- a/mriqc/workflows/functional/output.py
+++ b/mriqc/workflows/functional/output.py
@@ -238,10 +238,10 @@ def init_func_report_wf(name="func_report_wf"):
     )
 
     if config.workflow.species.lower() in ("rat", "mouse"):
-        mosaic_mean.inputs.view = ("coronal", "axial")
-        mosaic_stddev.inputs.view = ("coronal", "axial")
-        mosaic_zoom.inputs.view = ("coronal", "axial")
-        mosaic_noise.inputs.view = ("coronal", "axial")
+        mosaic_mean.inputs.view = ["coronal", "axial"]
+        mosaic_stddev.inputs.view = ["coronal", "axial"]
+        mosaic_zoom.inputs.view = ["coronal", "axial"]
+        mosaic_noise.inputs.view = ["coronal", "axial"]
 
     plot_bmask = pe.Node(
         PlotContours(


### PR DESCRIPTION
Fix for bug that obstructs rodent pipeline, because PlotMosaic expects lists of orientations, not tuples. 