### PR TITLE
FIX: Better handling of BIDS cached indexation

### DIFF
--- a/mriqc/cli/parser.py
+++ b/mriqc/cli/parser.py
@@ -209,6 +209,12 @@ Automated Quality Control and visual reports for Quality Assessment of structura
         help="Path to an existing PyBIDS database folder, for faster indexing "
         "(especially useful for large datasets).",
     )
+    g_bids.add_argument(
+        "--bids-database-wipe",
+        action="store_true",
+        default=False,
+        help="Wipe out previously existing BIDS indexing caches, forcing re-indexing.",
+    )
 
     # General performance
     g_perfm = parser.add_argument_group("Options to handle performance")


### PR DESCRIPTION
Although convenient, the user experience of the previous implementation was really bad and already surfacing issues. This should make caching less aggressive, and the new ``--bids-database-wipe`` flag make the clean-up operation more transparent.