### PR TITLE
CI: Simplify GitHub actions checks and update action versions

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -10,6 +10,13 @@ on:
   pull_request:
     branches: [ master, 'maint/*' ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   build:
     if: "!startsWith(github.ref, 'refs/tags/') && !contains(github.event.head_commit.message, '[skip ci]')"

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -55,6 +55,7 @@ jobs:
         INSTALLED_VERSION=$(python -c 'import mriqc as qc; print(qc.__version__, end="")')
         echo "INSTALLED: \"${INSTALLED_VERSION}\""
         test "${INSTALLED_VERSION}" = "${THISVERSION}"
+        rm -r /tmp/pip
     - name: Install in confined environment [sdist]
       run: |
         python -m venv /tmp/install_sdist
@@ -63,6 +64,7 @@ jobs:
         INSTALLED_VERSION=$(python -c 'import mriqc as qc; print(qc.__version__, end="")')
         echo "INSTALLED: \"${INSTALLED_VERSION}\""
         test "${INSTALLED_VERSION}" = "${THISVERSION}"
+        rm -r /tmp/install_sdist
     - name: Install in confined environment [wheel]
       run: |
         python -m venv /tmp/install_wheel
@@ -71,6 +73,7 @@ jobs:
         INSTALLED_VERSION=$(python -c 'import mriqc as qc; print(qc.__version__, end="")')
         echo "INSTALLED: \"${INSTALLED_VERSION}\""
         test "${INSTALLED_VERSION}" = "${THISVERSION}"
+        rm -r /tmp/install_wheel
 
   flake8:
     runs-on: ubuntu-latest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -67,7 +67,7 @@ jobs:
       run: |
         python -m venv /tmp/install_wheel
         source /tmp/install_wheel/bin/activate
-        python -m pip install /dist/mriqc*.whl
+        python -m pip install dist/mriqc*.whl
         INSTALLED_VERSION=$(python -c 'import mriqc as qc; print(qc.__version__, end="")')
         echo "INSTALLED: \"${INSTALLED_VERSION}\""
         test "${INSTALLED_VERSION}" = "${THISVERSION}"

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -37,13 +37,6 @@ jobs:
       run: |
         pipx run build
         pipx run twine check dist/mriqc-*
-    - uses: actions/cache@v3
-      with:
-        path: ~/.cache/pip
-        key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: |
-          pip-cache-${{ matrix.python-version }}
-          pip-cache-
     - name: Interpolate version
       run: |
         # Interpolate version

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,38 +17,26 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.11']
-        pip: ["pip==21.2", "pip~=23.0"]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Fetch all tags (for setuptools_scm to work)
-      run: |
-        /usr/bin/git -c protocol.version=2 fetch --tags --prune --unshallow origin
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v1
-      with:
-        path: $HOME/.cache/pip
-        key: pip-cache-v1
-        restore-keys: |
-          pip-cache-
-    - name: Build in confined environment and interpolate version
+    - name: Build and check package
       run: |
-        python -m venv /tmp/buildenv
-        source /tmp/buildenv/bin/activate
-        python -m pip install -U build hatch hatchling pip twine docutils wheel
-        
-        python -m build -s -w
-        python -m twine check dist/mriqc-*
-        mv dist /tmp/package
-        rm -rf mriqc.egg-info/
+        pipx run build
+        pipx run twine check dist/mriqc-*
+    - name: Interpolate version
+      run: |
         # Interpolate version
         if [[ "$GITHUB_REF" == refs/tags/* ]]; then
           TAG=${GITHUB_REF##*/}
         fi
-        THISVERSION=$( python -m hatch version | tail -n1 | xargs )
+        THISVERSION=$( pipx run hatch version | tail -n1 | xargs )
         THISVERSION=${TAG:-$THISVERSION}
         echo "Expected VERSION: \"${THISVERSION}\""
         echo "THISVERSION=${THISVERSION}" >> $GITHUB_ENV
@@ -56,28 +44,23 @@ jobs:
       run: |
         python -m venv /tmp/pip
         source /tmp/pip/bin/activate
-        python -m pip install -U hatch hatchling "${{ matrix.pip }}" wheel "cython==3.0.0b2" "numpy ~=1.20" scipy
         python -m pip install .
         INSTALLED_VERSION=$(python -c 'import mriqc as qc; print(qc.__version__, end="")')
-        echo "VERSION: \"${THISVERSION}\""
         echo "INSTALLED: \"${INSTALLED_VERSION}\""
         test "${INSTALLED_VERSION}" = "${THISVERSION}"
     - name: Install in confined environment [sdist]
       run: |
         python -m venv /tmp/install_sdist
         source /tmp/install_sdist/bin/activate
-        python -m pip install -U hatch hatchling "${{ matrix.pip }}" wheel "cython==3.0.0b2" "numpy ~=1.20" scipy
-        python -m pip install /tmp/package/mriqc*.tar.gz
+        python -m pip install dist/mriqc*.tar.gz
         INSTALLED_VERSION=$(python -c 'import mriqc as qc; print(qc.__version__, end="")')
-        echo "VERSION: \"${THISVERSION}\""
         echo "INSTALLED: \"${INSTALLED_VERSION}\""
         test "${INSTALLED_VERSION}" = "${THISVERSION}"
     - name: Install in confined environment [wheel]
       run: |
         python -m venv /tmp/install_wheel
         source /tmp/install_wheel/bin/activate
-        python -m pip install -U hatch hatchling "${{ matrix.pip }}" wheel "cython==3.0.0b2" "numpy ~=1.20" scipy
-        python -m pip install /tmp/package/mriqc*.whl
+        python -m pip install /dist/mriqc*.whl
         INSTALLED_VERSION=$(python -c 'import mriqc as qc; print(qc.__version__, end="")')
         echo "INSTALLED: \"${INSTALLED_VERSION}\""
         test "${INSTALLED_VERSION}" = "${THISVERSION}"
@@ -85,9 +68,9 @@ jobs:
   flake8:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - run: pip install flake8-pyproject 
@@ -96,9 +79,9 @@ jobs:
   codespell:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - run: pip install codespell tomli

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -79,20 +79,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.9
+    - name: Set up Python
       uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
-    - run: pip install flake8-pyproject 
-    - run: flake8 mriqc/
+    - run: pipx run flake8-pyproject mriqc/
 
   codespell:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
-    - run: pip install codespell tomli
-    - run: codespell
+    - uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -40,8 +40,9 @@ jobs:
     - uses: actions/cache@v3
       with:
         path: ~/.cache/pip
-        key: pip-cache-${{ hashFiles('**/requirements.txt') }}
+        key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt') }}
         restore-keys: |
+          pip-cache-${{ matrix.python-version }}
           pip-cache-
     - name: Interpolate version
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -37,6 +37,12 @@ jobs:
       run: |
         pipx run build
         pipx run twine check dist/mriqc-*
+    - uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: pip-cache-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          pip-cache-
     - name: Interpolate version
       run: |
         # Interpolate version


### PR DESCRIPTION
This drops old pip and use of venv for build, and uses pipx for tools to eliminate some pip installs altogether.

It also drops the pip cache. This is generally not a bottleneck, and I'm guessing it's the cause of the space limitations @celprov mentioned in #1137.