### PR TITLE
FIX: Use simpler DWI reference workflow

### DIFF
--- a/mriqc/workflows/diffusion/base.py
+++ b/mriqc/workflows/diffusion/base.py
@@ -99,14 +99,12 @@ def dmri_qc_workflow(name="dwiMRIQC"):
     inputnode.iterables = [("in_file", dataset)]
 
     datalad_get = pe.Node(
-        DataladIdentityInterface(
-            fields=["in_file"], dataset_path=config.execution.bids_dir),
+        DataladIdentityInterface(fields=["in_file"], dataset_path=config.execution.bids_dir),
         name="datalad_get",
     )
 
     outputnode = pe.Node(
-        niu.IdentityInterface(
-            fields=["qc", "mosaic", "out_group", "out_dvars", "out_fd"]),
+        niu.IdentityInterface(fields=["qc", "mosaic", "out_group", "out_dvars", "out_fd"]),
         name="outputnode",
     )
 
@@ -122,11 +120,9 @@ def dmri_qc_workflow(name="dwiMRIQC"):
     # Workflow --------------------------------------------------------
 
     # 1. Read metadata & bvec/bval, estimate number of shells, extract and split B0s
-    meta = pe.Node(ReadDWIMetadata(
-        index_db=config.execution.bids_database_dir), name="metadata")
+    meta = pe.Node(ReadDWIMetadata(index_db=config.execution.bids_database_dir), name="metadata")
     shells = pe.Node(NumberOfShells(), name="shells")
-    get_shells = pe.MapNode(
-        ExtractB0(), name="get_shells", iterfield=["b0_ixs"])
+    get_shells = pe.MapNode(ExtractB0(), name="get_shells", iterfield=["b0_ixs"])
     hmc_shells = pe.MapNode(
         Volreg(args="-Fourier -twopass", zpad=4, outputtype="NIFTI_GZ"),
         name="hmc_shells",
@@ -287,8 +283,7 @@ def compute_iqms(name="ComputeIQMs"):
         name="outputnode",
     )
 
-    meta = pe.Node(ReadSidecarJSON(
-        index_db=config.execution.bids_database_dir), name="metadata")
+    meta = pe.Node(ReadSidecarJSON(index_db=config.execution.bids_database_dir), name="metadata")
 
     addprov = pe.Node(
         AddProvenance(modality="dwi"),
@@ -372,11 +367,9 @@ def dmri_bmsk_workflow(name="dmri_brainmask", omp_nthreads=None):
     from mriqc.interfaces.synthstrip import SynthStrip
     from mriqc.workflows.anatomical.base import _apply_bias_correction
 
-    inputnode = pe.Node(niu.IdentityInterface(
-        fields=["in_file"]), name="inputnode")
+    inputnode = pe.Node(niu.IdentityInterface(fields=["in_file"]), name="inputnode")
     outputnode = pe.Node(
-        niu.IdentityInterface(
-            fields=["out_corrected", "out_brain", "bias_image", "out_mask"]),
+        niu.IdentityInterface(fields=["out_corrected", "out_brain", "bias_image", "out_mask"]),
         name="outputnode",
     )
 
@@ -398,8 +391,7 @@ def dmri_bmsk_workflow(name="dmri_brainmask", omp_nthreads=None):
     )
 
     final_masked = pe.Node(ApplyMask(), name="final_masked")
-    final_inu = pe.Node(niu.Function(
-        function=_apply_bias_correction), name="final_inu")
+    final_inu = pe.Node(niu.Function(function=_apply_bias_correction), name="final_inu")
 
     workflow = pe.Workflow(name=name)
     # fmt: off
@@ -462,14 +454,8 @@ def init_dmriref_wf(
     from niworkflows.interfaces.header import ValidateImage
 
     workflow = pe.Workflow(name=name)
-    inputnode = pe.Node(
-        niu.IdentityInterface(fields=["in_file"]),
-            fields=[
-                "in_file",
-                "ref_file",
-                "validation_report",
-            ]
-        ),
+    inputnode = pe.Node(niu.IdentityInterface(fields=["in_file"]),name="inputnode")
+    outputnode = pe.Node(niu.IdentityInterface(fields=["in_file", "ref_file", "validation_report"]),
         name="outputnode",
     )
 
@@ -520,10 +506,8 @@ def hmc_workflow(name="dMRI_HMC"):
 
     workflow = pe.Workflow(name=name)
 
-    inputnode = pe.Node(niu.IdentityInterface(
-        fields=["in_file", "reference"]), name="inputnode")
-    outputnode = pe.Node(niu.IdentityInterface(
-        fields=["out_file", "out_fd"]), name="outputnode")
+    inputnode = pe.Node(niu.IdentityInterface(fields=["in_file", "reference"]), name="inputnode")
+    outputnode = pe.Node(niu.IdentityInterface(fields=["out_file", "out_fd"]), name="outputnode")
 
     # calculate hmc parameters
     hmc = pe.Node(
@@ -592,8 +576,7 @@ def epi_mni_align(name="SpatialNormalization"):
         name="outputnode",
     )
 
-    n4itk = pe.Node(N4BiasFieldCorrection(
-        dimension=3, copy_header=True), name="SharpenEPI")
+    n4itk = pe.Node(N4BiasFieldCorrection(dimension=3, copy_header=True), name="SharpenEPI")
 
     norm = pe.Node(
         RobustMNINormalization(
@@ -613,8 +596,7 @@ def epi_mni_align(name="SpatialNormalization"):
 
     if config.workflow.species.lower() == "human":
         norm.inputs.reference_image = str(
-            get_template(config.workflow.template_id,
-                         resolution=2, suffix="boldref")
+            get_template(config.workflow.template_id, resolution=2, suffix="boldref")
         )
         norm.inputs.reference_mask = str(
             get_template(
@@ -630,8 +612,7 @@ def epi_mni_align(name="SpatialNormalization"):
 
         n4itk.inputs.shrink_factor = 1
         n4itk.inputs.n_iterations = [50] * 4
-        norm.inputs.reference_image = str(get_template(
-            config.workflow.template_id, suffix="T2w"))
+        norm.inputs.reference_image = str(get_template(config.workflow.template_id, suffix="T2w"))
         norm.inputs.reference_mask = str(
             get_template(
                 config.workflow.template_id,
@@ -640,8 +621,7 @@ def epi_mni_align(name="SpatialNormalization"):
             )[0]
         )
 
-        bspline_grid = pe.Node(niu.Function(
-            function=_bspline_grid), name="bspline_grid")
+        bspline_grid = pe.Node(niu.Function(function=_bspline_grid), name="bspline_grid")
 
         # fmt: off
         workflow.connect([

--- a/mriqc/workflows/diffusion/base.py
+++ b/mriqc/workflows/diffusion/base.py
@@ -48,6 +48,7 @@ from nipype.pipeline import engine as pe
 from mriqc.interfaces.datalad import DataladIdentityInterface
 from mriqc.workflows.diffusion.output import init_dwi_report_wf
 
+DEFAULT_MEMORY_MIN_GB = 0.01
 
 def dmri_qc_workflow(name="dwiMRIQC"):
     """
@@ -465,8 +466,9 @@ def init_dmriref_wf(
     """
     from niworkflows.interfaces.bold import NonsteadyStatesDetector
     from niworkflows.interfaces.images import RobustAverage
+    from niworkflows.interfaces.header import ValidateImage
 
-    workflow = Workflow(name=name)
+    workflow = pe.Workflow(name=name)
     workflow.__desc__ = f"""\
         First, a reference volume was generated{' from the shortest echo of the BOLD run' * multiecho},
         using a custom methodology of *fMRIPrep*, for use in head motion correction.

--- a/mriqc/workflows/diffusion/base.py
+++ b/mriqc/workflows/diffusion/base.py
@@ -50,6 +50,7 @@ from mriqc.workflows.diffusion.output import init_dwi_report_wf
 
 DEFAULT_MEMORY_MIN_GB = 0.01
 
+
 def dmri_qc_workflow(name="dwiMRIQC"):
     """
     Initialize the dMRI-QC workflow.
@@ -449,13 +450,13 @@ def init_dmriref_wf(
     ref_file : str
         Reference image to which DWI series is motion corrected
     """
-    from niworkflows.interfaces.bold import NonsteadyStatesDetector
     from niworkflows.interfaces.images import RobustAverage
     from niworkflows.interfaces.header import ValidateImage
 
     workflow = pe.Workflow(name=name)
-    inputnode = pe.Node(niu.IdentityInterface(fields=["in_file"]),name="inputnode")
-    outputnode = pe.Node(niu.IdentityInterface(fields=["in_file", "ref_file", "validation_report"]),
+    inputnode = pe.Node(niu.IdentityInterface(fields=["in_file"]), name="inputnode")
+    outputnode = pe.Node(
+        niu.IdentityInterface(fields=["in_file", "ref_file", "validation_report"]),
         name="outputnode",
     )
 
@@ -470,7 +471,6 @@ def init_dmriref_wf(
     )
 
     gen_avg = pe.Node(RobustAverage(), name="gen_avg", mem_gb=1)
-
 
     # fmt: off
     workflow.connect([

--- a/mriqc/workflows/diffusion/base.py
+++ b/mriqc/workflows/diffusion/base.py
@@ -95,8 +95,7 @@ def dmri_qc_workflow(name="dwiMRIQC"):
 
     # Define workflow, inputs and outputs
     # 0. Get data, put it in RAS orientation
-    inputnode = pe.Node(niu.IdentityInterface(
-        fields=["in_file"]), name="inputnode")
+    inputnode = pe.Node(niu.IdentityInterface(fields=["in_file"]), name="inputnode")
     inputnode.iterables = [("in_file", dataset)]
 
     datalad_get = pe.Node(
@@ -144,7 +143,7 @@ def dmri_qc_workflow(name="dwiMRIQC"):
     drift = pe.Node(CorrectSignalDrift(), name="drift")
 
     # 2. Generate B0 reference
-    dwi_reference_wf = init_dmriref_wf()
+    dwi_reference_wf = init_dmriref_wf(name="dwi_reference_wf")
 
     # 3. Calculate brainmask
     dmri_bmsk = dmri_bmsk_workflow(omp_nthreads=config.nipype.omp_nthreads)
@@ -447,12 +446,6 @@ def init_dmriref_wf(
     ----------
     in_file : :obj:`str`
         dMRI series NIfTI file
-    multiecho : :obj:`bool`
-        If multiecho data was supplied, data from the first echo will be selected
-    name : :obj:`str`
-        Name of workflow (default: ``init_dmriref_wf``)
-
-    Inputs
     ------
     in_file : str
         series NIfTI file
@@ -469,17 +462,8 @@ def init_dmriref_wf(
     from niworkflows.interfaces.header import ValidateImage
 
     workflow = pe.Workflow(name=name)
-    workflow.__desc__ = f"""\
-        First, a reference volume was generated{' from the shortest echo of the BOLD run' * multiecho},
-        using a custom methodology of *fMRIPrep*, for use in head motion correction.
-        """
-
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=["in_file", "dummy_scans"]),
-        name="inputnode",
-    )
-    outputnode = pe.Node(
-        niu.IdentityInterface(
+        niu.IdentityInterface(fields=["in_file"]),
             fields=[
                 "in_file",
                 "ref_file",
@@ -491,7 +475,7 @@ def init_dmriref_wf(
 
     # Simplify manually setting input image
     if in_file is not None:
-        inputnode.inputs.bold_file = in_file
+        niu.IdentityInterface(fields=["in_file"]),
 
     val_bold = pe.Node(
         ValidateImage(),


### PR DESCRIPTION
I've made the change to replace the reference node based on #1125 (thanks @effigies  for the instruction).  Here is what I did:
1. copied this [function](https://github.com/nipreps/fmriprep/blob/next/fmriprep/workflows/bold/reference.py) into `mriqc/workflows/diffusion/base.py`, just above `hmc_workflow`, named as `init_dmriref_wf`
2. removed the dummy scan calculation in `init_dmriref_wf`, because it's not used anywhere in the current context
3. changed the docsting to be less BOLD focused.
4. modified the node `dwi_reference_wf`
5. changed the corresponding connections with `dwi_reference_wf` in the workflow