### PR TITLE
FIX: temporary fix of the missing dwi key

### DIFF
--- a/mriqc/reports/group.py
+++ b/mriqc/reports/group.py
@@ -200,6 +200,7 @@ def gen_html(csv_file, mod, csv_failed=None, out_file=None):
                 None,
             ),
         ],
+        "dwi": [],
     }
 
     if csv_file.suffix == ".csv":


### PR DESCRIPTION
We need to complete the dictionary with the list of IQMs associated with dwi, but it is not known at the moment, so for now the temporary fix is to add the 'dwi' key associated with an empty list.

Linked to #1173.