### PR TITLE
FIX: Remove FD as an ``iterfield`` in ``MapNode`` causing crash with ME-BOLD

### DIFF
--- a/mriqc/workflows/functional/base.py
+++ b/mriqc/workflows/functional/base.py
@@ -376,7 +376,7 @@ def compute_iqms(name="ComputeIQMs"):
         GatherTimeseries(mpars_source="AFNI"),
         name="timeseries",
         mem_gb=mem_gb * 3,
-        iterfield=["dvars", "outliers", "quality", "fd"]
+        iterfield=["dvars", "outliers", "quality"]
     )
 
     # fmt: off


### PR DESCRIPTION
Only one FD timeserie is computed in a multi-echo dataset, unlike DVARS, quality, and outliers for which one timeserie per echo is computed.
Closes #1178 