### PR TITLE
MAINT: Using `.strip()` with multi-character strings is misleading

### DIFF
--- a/mriqc/workflows/anatomical/base.py
+++ b/mriqc/workflows/anatomical/base.py
@@ -813,15 +813,24 @@ def gradient_threshold(in_file, brainmask, thresh=15.0, out_file=None, aniso=Fal
 
 
 def _get_imgtype(in_file):
-    from pathlib import Path
-
-    return int(Path(in_file).name.rstrip(".gz").rstrip(".nii").split("_")[-1][1])
+    return int(_get_mod(in_file)[1])
 
 
 def _get_mod(in_file):
     from pathlib import Path
 
-    return Path(in_file).name.rstrip(".gz").rstrip(".nii").split("_")[-1]
+    in_file = Path(in_file).name
+    try:  # Python ≥ 3.9
+        in_file = in_file.removesuffix(".gz")
+    except AttributeError:  # Python < 3.9
+        if in_file.endswith(".gz"):
+            in_file = in_file[:-len(".gz")]
+    try:  # Python ≥ 3.9
+        in_file = in_file.removesuffix(".nii")
+    except AttributeError:  # Python < 3.9
+        if in_file.endswith(".nii"):
+            in_file = in_file[:-len(".nii")]
+    return in_file.split("_")[-1]
 
 
 def _pop(inlist):


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/strip-with-multi-characters/