### PR TITLE
FIX: Include ``dwidenoise`` within docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,6 +149,11 @@ COPY --from=freesurfer/synthstrip@sha256:f19578e5f033f2c707fa66efc8b3e11440569fa
 
 ENV FREESURFER_HOME=/opt/freesurfer
 
+RUN apt update && apt install --no-install-recommends -y libtiff5 libpng16-16
+
+COPY --from=mrtrix3/mrtrix3:3.0.4 /opt/mrtrix3/bin/dwidenoise /usr/local/bin
+COPY --from=mrtrix3/mrtrix3:3.0.4 /opt/mrtrix3/lib/libmrtrix.so /usr/local/lib
+
 # Container Sentinel
 ENV IS_DOCKER_8395080871=1
 


### PR DESCRIPTION
Implements [@effigies' solution](https://github.com/nipreps/mriqc/issues/1175#issuecomment-1917588140) leveraging Docker multi-staged builds.

Checked linked libraries within the Docker container:

```
$ ldd /usr/local/bin/dwidenoise
	linux-vdso.so.1 (0x00007fff6db65000)
	libmrtrix.so => /usr/local/bin/../lib/libmrtrix.so (0x00007f4e2b757000)
	libstdc++.so.6 => /opt/conda/lib/libstdc++.so.6 (0x00007f4e2b574000)
	libm.so.6 => /usr/lib/x86_64-linux-gnu/libm.so.6 (0x00007f4e2b48d000)
	libgcc_s.so.1 => /opt/conda/lib/libgcc_s.so.1 (0x00007f4e2b472000)
	libpthread.so.0 => /usr/lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f4e2b46d000)
	libc.so.6 => /usr/lib/x86_64-linux-gnu/libc.so.6 (0x00007f4e2b242000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f4e2bac2000)
	libz.so.1 => /opt/conda/lib/libz.so.1 (0x00007f4e2b227000)
	libtiff.so.5 => /usr/lib/x86_64-linux-gnu/libtiff.so.5 (0x00007f4e2b19f000)
	libpng16.so.16 => /opt/conda/lib/libpng16.so.16 (0x00007f4e2b162000)
	librt.so.1 => /usr/lib/x86_64-linux-gnu/librt.so.1 (0x00007f4e2b15d000)
	libwebp.so.7 => /opt/conda/lib/libwebp.so.7 (0x00007f4e2b0bb000)
	libzstd.so.1 => /opt/conda/lib/libzstd.so.1 (0x00007f4e2afa7000)
	liblzma.so.5 => /opt/conda/lib/liblzma.so.5 (0x00007f4e2af7e000)
	libjbig.so.0 => /usr/lib/x86_64-linux-gnu/libjbig.so.0 (0x00007f4e2af6d000)
	libjpeg.so.8 => /opt/conda/lib/libjpeg.so.8 (0x00007f4e2ae87000)
	libdeflate.so.0 => /opt/conda/lib/libdeflate.so.0 (0x00007f4e2ae71000)
	libsharpyuv.so.0 => /opt/conda/lib/./libsharpyuv.so.0 (0x00007f4e2ae65000)

ldd /usr/local/lib/libmrtrix.so
	linux-vdso.so.1 (0x00007ffc0a0b6000)
	libz.so.1 => /opt/conda/lib/libz.so.1 (0x00007f431b203000)
	libtiff.so.5 => /usr/lib/x86_64-linux-gnu/libtiff.so.5 (0x00007f431b17b000)
	libpng16.so.16 => /opt/conda/lib/libpng16.so.16 (0x00007f431b13e000)
	libstdc++.so.6 => /opt/conda/lib/libstdc++.so.6 (0x00007f431af5b000)
	libm.so.6 => /usr/lib/x86_64-linux-gnu/libm.so.6 (0x00007f431ae74000)
	libgcc_s.so.1 => /opt/conda/lib/libgcc_s.so.1 (0x00007f431ae57000)
	libpthread.so.0 => /usr/lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f431ae52000)
	libc.so.6 => /usr/lib/x86_64-linux-gnu/libc.so.6 (0x00007f431ac29000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f431b4d5000)
	libwebp.so.7 => /opt/conda/lib/libwebp.so.7 (0x00007f431ab89000)
	libzstd.so.1 => /opt/conda/lib/libzstd.so.1 (0x00007f431aa75000)
	liblzma.so.5 => /opt/conda/lib/liblzma.so.5 (0x00007f431aa4c000)
	libjbig.so.0 => /usr/lib/x86_64-linux-gnu/libjbig.so.0 (0x00007f431aa39000)
	libjpeg.so.8 => /opt/conda/lib/libjpeg.so.8 (0x00007f431a953000)
	libdeflate.so.0 => /opt/conda/lib/libdeflate.so.0 (0x00007f431a93d000)
	librt.so.1 => /usr/lib/x86_64-linux-gnu/librt.so.1 (0x00007f431a938000)
	libsharpyuv.so.0 => /opt/conda/lib/./libsharpyuv.so.0 (0x00007f431a92e000)
```

And also tested *MRIQC* locally on DWI data.

Resolves: #1175.