### PR TITLE
FIX: DIPY not listed as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 license = "Apache-2.0"
 requires-python = ">=3.8"
 dependencies = [
+    "dipy",
     'importlib_resources; python_version < "3.9"',
     # jinja2 imports deprecated function removed in 2.1
     "markupsafe ~= 2.0.1",


### PR DESCRIPTION
An oversight from the new DWI pipeline inclusion.