### PR TITLE
FIX: Move from ``pkg_resources`` to ``niworkflows.data.Loader``

### DIFF
--- a/mriqc/data/config.py
+++ b/mriqc/data/config.py
@@ -23,7 +23,7 @@
 """Utilities: Jinja2 templates."""
 from pathlib import Path
 
-from pkg_resources import resource_filename as pkgrf
+from niworkflows.data import Loader
 
 
 class GroupTemplate:
@@ -37,7 +37,7 @@ class GroupTemplate:
     def __init__(self):
         import jinja2
 
-        self.template_str = pkgrf("mriqc", "data/reports/group.html")
+        self.template_str = Loader(__package__)("data/reports/group.html")
         self.env = jinja2.Environment(
             loader=jinja2.FileSystemLoader(searchpath="/"),
             trim_blocks=True,

--- a/mriqc/interfaces/common/ensure_size.py
+++ b/mriqc/interfaces/common/ensure_size.py
@@ -37,12 +37,13 @@ from nipype.interfaces.base import (
     isdefined,
     traits,
 )
-from pkg_resources import resource_filename as pkgrf
+from niworkflows.data import Loader
 
 OUT_FILE_NAME = "{prefix}_resampled{ext}"
 OUT_MASK_NAME = "{prefix}_resmask{ext}"
 REF_FILE_NAME = "resample_ref.nii.gz"
 REF_MASK_NAME = "mask_ref.nii.gz"
+load_data = Loader(__package__)
 
 
 class EnsureSizeInputSpec(BaseInterfaceInputSpec):
@@ -146,7 +147,7 @@ class EnsureSize(SimpleInterface):
                 input_image=self.inputs.in_file,
                 reference_image=REF_FILE_NAME,
                 interpolation="LanczosWindowedSinc",
-                transforms=[pkgrf("mriqc", "data/itk_identity.tfm")],
+                transforms=[load_data("data/itk_identity.tfm")],
                 output_image=out_file,
             ).run()
 
@@ -167,7 +168,7 @@ class EnsureSize(SimpleInterface):
                     input_image=self.inputs.in_mask,
                     reference_image=REF_MASK_NAME,
                     interpolation="NearestNeighbor",
-                    transforms=[pkgrf("mriqc", "data/itk_identity.tfm")],
+                    transforms=[load_data("data/itk_identity.tfm")],
                     output_image=out_mask,
                 ).run()
 

--- a/mriqc/reports/group.py
+++ b/mriqc/reports/group.py
@@ -33,7 +33,7 @@ def gen_html(csv_file, mod, csv_failed=None, out_file=None):
     import datetime
     import os.path as op
 
-    from pkg_resources import resource_filename as pkgrf
+    from niworkflows.data import Loader
 
     from .. import __version__ as ver
     from mriqc.data.config import GroupTemplate
@@ -42,6 +42,8 @@ def gen_html(csv_file, mod, csv_failed=None, out_file=None):
         from io import StringIO as TextIO
     else:
         from io import BytesIO as TextIO
+
+    load_data = Loader(__package__)
 
     QCGROUPS = {
         "T1w": [
@@ -266,21 +268,13 @@ def gen_html(csv_file, mod, csv_failed=None, out_file=None):
             "csv_groups": csv_groups,
             "failed": failed,
             "boxplots_js": open(
-                pkgrf(
-                    "mriqc",
-                    op.join("data", "reports", "embed_resources", "boxplots.js"),
-                )
+                load_data("data/reports/embed_resources/boxplots.js"),
             ).read(),
             "d3_js": open(
-                pkgrf(
-                    "mriqc", op.join("data", "reports", "embed_resources", "d3.min.js")
-                )
+                load_data("data/reports/embed_resources/d3.min.js"),
             ).read(),
             "boxplots_css": open(
-                pkgrf(
-                    "mriqc",
-                    op.join("data", "reports", "embed_resources", "boxplots.css"),
-                )
+                load_data("data/reports/embed_resources/boxplots.css"),
             ).read(),
         },
         out_file,

--- a/mriqc/reports/individual.py
+++ b/mriqc/reports/individual.py
@@ -23,8 +23,10 @@
 """Encapsulates report generation functions."""
 from pathlib import Path
 from json import loads
-from pkg_resources import resource_filename as pkgrf
 from nireports.assembler.report import Report
+from niworkflows.data import Loader
+
+_load_data = Loader(__package__)
 
 
 def generate_reports():
@@ -86,7 +88,7 @@ def _single_report(in_file):
         config.execution.output_dir,
         config.execution.run_uuid,
         reportlets_dir=config.execution.work_dir / "reportlets",
-        bootstrap_file=pkgrf("mriqc", f"data/bootstrap-{report_type}.yml"),
+        bootstrap_file=_load_data(f"data/bootstrap-{report_type}.yml"),
         metadata={
             "dataset": config.execution.dsname,
             "about-metadata": {

--- a/mriqc/testing.py
+++ b/mriqc/testing.py
@@ -24,9 +24,11 @@
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import mkdtemp
-
-from pkg_resources import resource_filename as pkgrf
 from toml import loads
+
+from niworkflows.data import Loader
+
+_load_data = Loader(__package__)
 
 
 @contextmanager
@@ -34,7 +36,7 @@ def mock_config():
     """Create a mock config for documentation and testing purposes."""
     from . import config
 
-    filename = Path(pkgrf("mriqc", "data/config-example.toml"))
+    filename = Path(_load_data("data/config-example.toml"))
     settings = loads(filename.read_text())
     for sectionname, configs in settings.items():
         if sectionname != "environment":
@@ -44,7 +46,7 @@ def mock_config():
     config.loggers.init()
 
     config.execution.work_dir = Path(mkdtemp())
-    config.execution.bids_dir = Path(pkgrf("mriqc", "data/tests/ds000005")).absolute()
+    config.execution.bids_dir = Path(_load_data("data/tests/ds000005")).absolute()
     config.execution.init()
 
     yield


### PR DESCRIPTION
``pkg_resources`` is deprecated as an API.