### PR TITLE
FIX: Typo in sorted(..., reverse=True) call

### DIFF
--- a/mriqc/workflows/anatomical/base.py
+++ b/mriqc/workflows/anatomical/base.py
@@ -804,7 +804,7 @@ def gradient_threshold(in_file, brainmask, thresh=15.0, out_file=None, aniso=Fal
     artmsk = np.zeros_like(mask)
     if nb_labels > 2:
         sizes = sim.sum(mask, label_im, list(range(nb_labels + 1)))
-        ordered = sorted(zip(sizes, list(range(nb_labels + 1))), reversed=True)
+        ordered = sorted(zip(sizes, list(range(nb_labels + 1))), reverse=True)
         for _, label in ordered[2:]:
             mask[label_im == label] = 0
             artmsk[label_im == label] = 1


### PR DESCRIPTION
Changed reversed to reverse in gradient_threshold function. Should address #1210 