### PR TITLE
FIX: Avert costly ``BIDSLayout.__repr__`` calls when saving config

### DIFF
--- a/mriqc/config.py
+++ b/mriqc/config.py
@@ -431,7 +431,6 @@ class execution(_Config):
         'bids_database_dir',
         'fs_license_file',
         'fs_subjects_dir',
-        'layout',
         'log_dir',
         'output_dir',
         'templateflow_home',
@@ -510,6 +509,11 @@ class execution(_Config):
                 database_path=cls.bids_database_dir,
                 indexer=_indexer,
             )
+
+            # Rewrite __repr__ to avoid the layout query and build the summary
+            # For a smallish dataset this takes one minute each time.
+            # See https://github.com/nipreps/mriqc/issues/1239
+            cls._layout.__class__.__repr__ = lambda x: f'BIDS Layout: {cls.bids_dir}'
 
         cls.layout = cls._layout
 


### PR DESCRIPTION
The layout is printed out as a string when writing the config file. The object's ``__repr__`` shows a summary of subjects and tasks, etc., which for large datasets can be very costly.

Rewriting the layout's ``__repr__`` effectively reduces runtime.

Resolves: #1236.

cc/ @effigies 