### PR TITLE
FIX: Exclude DWI runs with insufficient orientations or missing bvals

### DIFF
--- a/mriqc/config.py
+++ b/mriqc/config.py
@@ -545,6 +545,8 @@ class workflow(_Config):
     """Turn on FFT based spike detector (slow)."""
     inputs = None
     """List of files to be processed with MRIQC."""
+    min_len_dwi = 5
+    """Minimum DWI length to be considered a "processable" dataset."""
     species = 'human'
     """Subject species to choose most appropriate template"""
     template_id = 'MNI152NLin2009cAsym'


### PR DESCRIPTION
This is the counterpart of #1120 for DWI.
In the case of DWI, this is easier to implement since bvals is a file expected to sit next to the NIfTI volume and should contain one column per volume in the forth dimension of the image.