### PR TITLE
FIX: Address issues that had broken the group reports

### DIFF
--- a/mriqc/data/config.py
+++ b/mriqc/data/config.py
@@ -42,7 +42,7 @@ class GroupTemplate:
             loader=jinja2.FileSystemLoader(searchpath='/'),
             trim_blocks=True,
             lstrip_blocks=True,
-            autoescape=True,
+            autoescape=False,  # noqa: S701
         )
 
     def compile(self, configs):

--- a/mriqc/reports/group.py
+++ b/mriqc/reports/group.py
@@ -245,12 +245,12 @@ def gen_html(csv_file, mod, csv_failed=None, out_file=None):
 
         for iqm in group:
             if iqm in datacols:
-                values = dataframe[[iqm]].values.tolist()
+                values = dataframe[[iqm]].values.ravel().tolist()
                 if values:
                     dfdict['iqm'] += [iqm] * nPart
                     dfdict['units'] += [units] * nPart
                     dfdict['value'] += values
-                    dfdict['label'] += dataframe[['label']].values.tolist()
+                    dfdict['label'] += dataframe[['label']].values.ravel().tolist()
 
         # Save only if there are values
         if dfdict['value']:


### PR DESCRIPTION
- [x] Disable autoescaping in Jinja replacement (bug introduced in #1203).
- [x] Restate `ravel()` in IQM processing (bug introduced in #1257).

Resolves: #1260.