### PR TITLE
FIX: Bug in *toml* loader crashing with mixed arrays in config

### DIFF
--- a/mriqc/config.py
+++ b/mriqc/config.py
@@ -665,7 +665,10 @@ def from_dict(sections):
 
 def load(filename):
     """Load settings from file."""
-    from toml import loads
+    try:
+        from tomllib import loads
+    except ModuleNotFoundError:  # Python < 3.11
+        from tomli import loads
 
     filename = Path(filename)
     sections = loads(filename.read_text())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "statsmodels",
   "templateflow",
   "toml",
+  "tomli >= 1.1.0; python_version < '3.11'",
   "torch >= 1.10.2",
 ]
 description = "Automated Quality Control and visual reports for Quality Assessment of structural (T1w, T2w) and functional MRI of the brain."


### PR DESCRIPTION
This happened, e.g., when trying to run MRIQC on datasets with both single-echo and multi-echo runs or with filters where some array had mixed types (e.g., `part: [null, 'mag']`).

Resolves: #1264.