### PR TITLE
MAINT: Flexibilize pandas pinned version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "nitransforms ~= 23.0",
   "niworkflows ~=1.10.1",
   "numpy ~=1.20",
-  "pandas ~=1.0",
+  "pandas",
   "pybids >= 0.15.6",
   "PyYAML",
   "scikit-learn",


### PR DESCRIPTION
I assume the pin comes from before outsourcing mriqc-learn. No need to keep it that tight and let other dependencies set their restrictions.