### PR TITLE
MAINT: Remove redundant licence definition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
 ]
 description = "Automated Quality Control and visual reports for Quality Assessment of structural (T1w, T2w) and functional MRI of the brain."
 dynamic = ["version"]
-license = "Apache-2.0"
 name = "mriqc"
 readme = "README.rst"
 requires-python = ">=3.8"


### PR DESCRIPTION
Drop the licence key, keep the licence classifier, as suggested by [PEP 639](https://peps.python.org/pep-0639/) draft.

From the [Python Packaging User Guide](https://packaging.python.org/):
> If you are using a standard, well-known license, it is not necessary to use this field. Instead, you should use one of the [classifiers](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#classifiers) starting with `License ::`.

Reported by [validate-pyproject](https://github.com/abravalheri/validate-pyproject/):
```console
$ validate-pyproject pyproject.toml 
Invalid file: pyproject.toml
[ERROR] `project.license` must be valid exactly by one definition (2 matches found):

    - keys:
        'file': {type: string}
      required: ['file']
    - keys:
        'text': {type: string}
      required: ['text']

$ 
```
and online:
https://learn.scientific-python.org/development/guides/repo-review/?repo=nipreps%2Fmriqc&branch=master