### PR TITLE
ENH: Crawl dataset's metadata only once and before Nipype's workflow

### DIFF
--- a/mriqc/cli/parser.py
+++ b/mriqc/cli/parser.py
@@ -490,6 +490,7 @@ def parse_args(args=None, namespace=None):
     from mriqc import __version__
     from mriqc._warnings import DATE_FMT, LOGGER_FMT, _LogFormatter
     from mriqc.messages import PARTICIPANT_START
+    from mriqc.utils.misc import initialize_meta_and_data
 
     parser = _build_parser()
     opts = parser.parse_args(args, namespace)
@@ -642,11 +643,7 @@ Please, check out your currently set filters {ffile}:
             f'MRIQC is unable to process the following modalities: {", ".join(unknown_mods)}.'
         )
 
-    # Estimate the biggest file size / leave 1GB if some file does not exist (datalad)
-    with suppress(FileNotFoundError):
-        config.workflow.biggest_file_gb = _get_biggest_file_size_gb(
-            config.workflow.inputs.values()
-        )
+    initialize_meta_and_data()
 
     # set specifics for alternative populations
     if opts.species.lower() != 'human':
@@ -660,17 +657,3 @@ Please, check out your currently set filters {ffile}:
             config.workflow.fd_radius = 7.5
             # block uploads for the moment; can be reversed before wider release
             config.execution.no_sub = True
-
-
-def _get_biggest_file_size_gb(files):
-    """Identify the largest file size (allows multi-echo groups)."""
-
-    import os
-
-    sizes = []
-    for file in files:
-        if isinstance(file, (list, tuple)):
-            sizes.append(_get_biggest_file_size_gb(file))
-        else:
-            sizes.append(os.path.getsize(file))
-    return max(sizes) / (1024**3)

--- a/mriqc/cli/parser.py
+++ b/mriqc/cli/parser.py
@@ -479,7 +479,6 @@ discourage its usage.""",
 
 def parse_args(args=None, namespace=None):
     """Parse args and run further checks on the command line."""
-    from contextlib import suppress
     from json import loads
     from logging import DEBUG, FileHandler
     from pathlib import Path
@@ -555,10 +554,9 @@ def parse_args(args=None, namespace=None):
     if output_dir == bids_dir:
         parser.error(
             'The selected output folder is the same as the input BIDS folder. '
-            'Please modify the output path (suggestion: %s).'
-            % bids_dir
+            f'Please modify the output path (suggestion: {bids_dir}).'
             / 'derivatives'
-            / ('mriqc-%s' % version.split('+')[0])
+            / ('mriqc-{}'.format(version.split('+')[0]))
         )
 
     if bids_dir in work_dir.parents:

--- a/mriqc/cli/run.py
+++ b/mriqc/cli/run.py
@@ -266,7 +266,10 @@ def main(argv=None):
             )
         ),
     )
-    config.to_filename(config.execution.log_dir / f'config-{config.execution.run_uuid}.toml')
+    config.to_filename(
+        config.execution.log_dir / f'config-{config.execution.run_uuid}.toml',
+        store_inputs=False,  # Inputs are not necessary anymore
+    )
     sys.exit(exitcode)
 
 

--- a/mriqc/interfaces/bids.py
+++ b/mriqc/interfaces/bids.py
@@ -44,7 +44,7 @@ class IQMFileSinkInputSpec(DynamicTraitedSpec, BaseInterfaceInputSpec):
     in_file = Str(mandatory=True, desc='path of input file')
     modality = Str(mandatory=True, desc='the qc type')
     entities = traits.Dict(desc='entities corresponding to the input')
-    subject_id = Str(mandatory=True, desc='the subject id')
+    subject_id = Str(desc='the subject id')
     session_id = traits.Either(None, Str, usedefault=True)
     task_id = traits.Either(None, Str, usedefault=True)
     acq_id = traits.Either(None, Str, usedefault=True)

--- a/mriqc/interfaces/bids.py
+++ b/mriqc/interfaces/bids.py
@@ -42,15 +42,19 @@ from mriqc.utils.misc import BIDS_COMP
 
 class IQMFileSinkInputSpec(DynamicTraitedSpec, BaseInterfaceInputSpec):
     in_file = Str(mandatory=True, desc='path of input file')
-    subject_id = Str(mandatory=True, desc='the subject id')
     modality = Str(mandatory=True, desc='the qc type')
+    entities = traits.Dict(desc='entities corresponding to the input')
+    subject_id = Str(mandatory=True, desc='the subject id')
     session_id = traits.Either(None, Str, usedefault=True)
     task_id = traits.Either(None, Str, usedefault=True)
     acq_id = traits.Either(None, Str, usedefault=True)
     rec_id = traits.Either(None, Str, usedefault=True)
     run_id = traits.Either(None, traits.Int, usedefault=True)
     dataset = Str(desc='dataset identifier')
-    dismiss_entities = traits.List(['part'], usedefault=True)
+    dismiss_entities = traits.List(
+        ['datatype', 'part', 'echo', 'extension', 'suffix'],
+        usedefault=True,
+    )
     metadata = traits.Dict()
     provenance = traits.Dict()
 
@@ -156,7 +160,7 @@ class IQMFileSink(SimpleInterface):
                 )
 
         # Fill in the "bids_meta" key
-        id_dict = {}
+        id_dict = self.inputs.entities if isdefined(self.inputs.entities) else {}
         for comp in BIDS_COMP:
             comp_val = getattr(self.inputs, comp, None)
             if isdefined(comp_val) and comp_val is not None:

--- a/mriqc/interfaces/webapi.py
+++ b/mriqc/interfaces/webapi.py
@@ -169,15 +169,17 @@ class UploadIQMs(SimpleInterface):
             config.loggers.interface.info(messages.QC_UPLOAD_COMPLETE)
             return runtime
 
-        errmsg = '\n'.join([
-            'Unsuccessful upload.',
-            f'Server response status {response.status_code}:',
-            response.text,
-            '',
-            '',
-            'Payload:',
-            json.dumps(payload, indent=2),
-        ])
+        errmsg = '\n'.join(
+            [
+                'Unsuccessful upload.',
+                f'Server response status {response.status_code}:',
+                response.text,
+                '',
+                '',
+                'Payload:',
+                json.dumps(payload, indent=2),
+            ]
+        )
         config.loggers.interface.warning(errmsg)
         if self.inputs.strict:
             raise RuntimeError(errmsg)
@@ -227,11 +229,7 @@ def upload_qc_metrics(
     data = deepcopy(in_data)
 
     # Check modality
-    modality = (
-        meta.get('modality', None)
-        or meta.get('suffix', None)
-        or modality
-    )
+    modality = meta.get('modality', None) or meta.get('suffix', None) or modality
     if modality not in ('T1w', 'bold', 'T2w'):
         errmsg = (
             'Submitting to MRIQCWebAPI: image modality should be "bold", "T1w", or "T2w", '
@@ -244,9 +242,7 @@ def upload_qc_metrics(
 
     # Check for fields with appended _id
     bids_meta_names = {k: k.replace('_id', '') for k in META_WHITELIST if k.endswith('_id')}
-    data['bids_meta'].update({
-        k: meta[v] for k, v in bids_meta_names.items() if v in meta
-    })
+    data['bids_meta'].update({k: meta[v] for k, v in bids_meta_names.items() if v in meta})
 
     # For compatibility with WebAPI. Should be rolled back to int
     if (run_id := data['bids_meta'].get('run_id', None)) is not None:

--- a/mriqc/utils/misc.py
+++ b/mriqc/utils/misc.py
@@ -68,6 +68,7 @@ BIDS_EXPR = """\
 (_rec-(?P<rec_id>[a-zA-Z0-9]+))?(_run-(?P<run_id>[a-zA-Z0-9]+))?\
 """
 
+
 async def worker(job: Callable[[], R], semaphore) -> R:
     async with semaphore:
         loop = asyncio.get_running_loop()
@@ -264,10 +265,7 @@ def _flatten_list(xs):
 def _datalad_get(input_list, nprocs=None):
     from mriqc import config
 
-    if (
-        not config.execution.bids_dir_datalad
-        or not config.execution.datalad_get
-    ):
+    if not config.execution.bids_dir_datalad or not config.execution.datalad_get:
         return
 
     # Delay datalad import until we're sure we'll need it
@@ -343,10 +341,7 @@ def _file_meta_and_size(
             _size_list.append(sizes_i)
             _valid_list.append(valid_i)
 
-        valid = (
-            all(_valid_list)
-            and len({_m['NumberOfVolumes'] for _m in metadata}) == 1
-        )
+        valid = all(_valid_list) and len({_m['NumberOfVolumes'] for _m in metadata}) == 1
         return metadata, entities, np.sum(_size_list), valid
 
     metadata = config.execution.layout.get_metadata(files)
@@ -458,7 +453,7 @@ def initialize_meta_and_data(
     for mod, input_list in config.workflow.inputs.items():
         config.loggers.cli.log(
             25,
-            f"Extracting metadata and entities for {len(input_list)} input runs "
+            f'Extracting metadata and entities for {len(input_list)} input runs '
             f"of modality '{mod}'...",
         )
 
@@ -485,13 +480,14 @@ def initialize_meta_and_data(
         )
 
         # Identify nonconformant files that need to be dropped (and drop them)
-        if (num_dropped := len(input_list) - np.sum(valid)):
+        if num_dropped := len(input_list) - np.sum(valid):
             config.loggers.workflow.warn(
                 f'{num_dropped} cannot be processed (too short or too long)'
             )
 
             filtered_results = [
-                _v[:-1] for _v in zip(input_list, metadata, entities, size, valid)
+                _v[:-1]
+                for _v in zip(input_list, metadata, entities, size, valid)
                 if _v[-1] is True
             ]
             input_list, metadata, entities, size = list(zip(*filtered_results))
@@ -505,6 +501,5 @@ def initialize_meta_and_data(
 
         config.loggers.cli.log(
             25,
-            f"File size ('{mod}'): {_max_size:.2f}|{np.mean(size):.2f} "
-            "GB [maximum|average].",
+            f"File size ('{mod}'): {_max_size:.2f}|{np.mean(size):.2f} " 'GB [maximum|average].',
         )

--- a/mriqc/utils/misc.py
+++ b/mriqc/utils/misc.py
@@ -447,8 +447,8 @@ def initialize_meta_and_data(
     _datalad_get(dataset)
 
     # Extract metadata and filesize
-    config.workflow.input_metadata = {}
-    config.workflow.input_entities = {}
+    config.workflow.inputs_metadata = {}
+    config.workflow.inputs_entities = {}
     config.workflow.biggest_file_gb = {}
     for mod, input_list in config.workflow.inputs.items():
         config.loggers.cli.log(
@@ -495,8 +495,8 @@ def initialize_meta_and_data(
 
         # Finalizing (write to config so that values are propagated)
         _max_size = np.max(size)
-        config.workflow.input_metadata[mod] = metadata
-        config.workflow.input_entities[mod] = entities
+        config.workflow.inputs_metadata[mod] = metadata
+        config.workflow.inputs_entities[mod] = entities
         config.workflow.biggest_file_gb[mod] = float(_max_size)  # Cast required to store YAML
 
         config.loggers.cli.log(

--- a/mriqc/utils/misc.py
+++ b/mriqc/utils/misc.py
@@ -22,17 +22,27 @@
 #
 """Helper functions."""
 
+from __future__ import annotations
+
+import asyncio
 import json
 from collections import OrderedDict
 from collections.abc import Iterable
+from functools import partial
+from os import cpu_count
 from pathlib import Path
+from typing import Callable, TypeVar
 
+import nibabel as nb
+import numpy as np
 import pandas as pd
 
 try:
     from collections.abc import MutableMapping
 except ImportError:
     from collections.abc import MutableMapping
+
+R = TypeVar('R')
 
 IMTYPES = {
     'T1w': 'anat',
@@ -57,6 +67,11 @@ BIDS_EXPR = """\
 (_task-(?P<task_id>[a-zA-Z0-9]+))?(_acq-(?P<acq_id>[a-zA-Z0-9]+))?\
 (_rec-(?P<rec_id>[a-zA-Z0-9]+))?(_run-(?P<run_id>[a-zA-Z0-9]+))?\
 """
+
+async def worker(job: Callable[[], R], semaphore) -> R:
+    async with semaphore:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, job)
 
 
 def reorder_csv(csv_file, out_file=None):
@@ -168,7 +183,7 @@ def generate_pred(derivatives_dir, output_dir, mod):
     # Drop duplicates
     dataframe.drop_duplicates(bdits_cols, keep='last', inplace=True)
 
-    out_csv = Path(output_dir) / ('%s_predicted_qa_csv' % mod)
+    out_csv = Path(output_dir) / f'{mod}_predicted_qa_csv'
     dataframe[bdits_cols + ['mriqc_pred']].to_csv(str(out_csv), index=False)
     return out_csv
 
@@ -179,7 +194,7 @@ def generate_tsv(output_dir, mod):
     """
 
     # If some were found, generate the CSV file and group report
-    out_tsv = output_dir / ('group_%s.tsv' % mod)
+    out_tsv = output_dir / (f'group_{mod}.tsv')
     jsonfiles = list(output_dir.glob(f'sub-*/**/{IMTYPES[mod]}/sub-*_{mod}.json'))
     if not jsonfiles:
         return None, out_tsv
@@ -249,7 +264,10 @@ def _flatten_list(xs):
 def _datalad_get(input_list, nprocs=None):
     from mriqc import config
 
-    if not config.execution.bids_dir_datalad:
+    if (
+        not config.execution.bids_dir_datalad
+        or not config.execution.datalad_get
+    ):
         return
 
     # Delay datalad import until we're sure we'll need it
@@ -273,3 +291,220 @@ def _datalad_get(input_list, nprocs=None):
             config.nipype.nprocs,
         ),
     )
+
+
+def _file_meta_and_size(
+    files: list | str,
+    volmin: int | None = 1,
+    volmax: int | None = None,
+):
+    """
+    Identify the largest file size (allows multi-echo groups).
+
+    Parameters
+    ----------
+    files : :obj:`list`
+        List of :obj:`os.pathlike` or sublist of :obj:`os.pathlike` (multi-echo case)
+        of files to be extracted.
+    volmin : :obj:`int`
+        Minimum number of volumes that inputs must have.
+    volmax : :obj:`int`
+        Maximum number of volumes that inputs must have.
+
+    Returns
+    -------
+    :obj:`tuple`
+        A tuple (metadata, entities, sizes, valid) of items containing the different
+        aspects extracted from the input(s).
+
+    """
+
+    import os
+
+    from mriqc import config
+
+    multifile = isinstance(files, (list, tuple))
+    if multifile:
+        metadata = []
+        entities = []
+        _size_list = []
+        _valid_list = []
+
+        for filename in files:
+            metadata_i, entities_i, sizes_i, valid_i = _file_meta_and_size(
+                filename,
+                volmin=volmin,
+                volmax=volmax,
+            )
+
+            # Add to output lists
+            metadata.append(metadata_i)
+            entities.append(entities_i)
+            _size_list.append(sizes_i)
+            _valid_list.append(valid_i)
+
+        valid = (
+            all(_valid_list)
+            and len({_m['NumberOfVolumes'] for _m in metadata}) == 1
+        )
+        return metadata, entities, np.sum(_size_list), valid
+
+    metadata = config.execution.layout.get_metadata(files)
+    entities = config.execution.layout.parse_file_entities(files)
+    size = os.path.getsize(files) / (1024**3)
+
+    metadata['FileSize'] = size
+    metadata['FileSizeUnits'] = 'GB'
+
+    try:
+        nii = nb.load(files)
+        nifti_len = nii.shape[3]
+    except nb.filebasedimages.ImageFileError:
+        nifti_len = None
+    except IndexError:  # shape has only 3 elements
+        nifti_len = 1 if nii.dataobj.ndim == 3 else -1
+
+    valid = True
+    if volmin is not None:
+        valid = nifti_len >= volmin
+
+    if valid and volmax is not None:
+        valid = nifti_len <= volmax
+
+    metadata['NumberOfVolumes'] = nifti_len
+
+    return metadata, entities, size, valid
+
+
+async def _extract_meta_and_size(
+    filelist: list,
+    volmin: int | None = 1,
+    volmax: int | None = None,
+    max_concurrent: int = min(cpu_count(), 12),
+) -> tuple[list, list, list, list]:
+    """
+    Extract corresponding metadata and file size in GB.
+
+    Parameters
+    ----------
+    filelist : :obj:`list`
+        List of :obj:`os.pathlike` or sublist of :obj:`os.pathlike` (multi-echo case)
+        of files to be extracted.
+    volmin : :obj:`int`
+        Minimum number of volumes that inputs must have.
+    volmax : :obj:`int`
+        Maximum number of volumes that inputs must have.
+    max_concurrent : :obj:`int`
+        Maximum number of concurrent coroutines (files or multi-echo sets).
+
+    Returns
+    -------
+    :obj:`tuple`
+        A tuple (metadata, entities, sizes, valid) of lists containing the different
+        aspects extracted from inputs.
+
+    """
+
+    semaphore = asyncio.Semaphore(max_concurrent)
+    tasks = []
+    for filename in filelist:
+        tasks.append(
+            asyncio.create_task(
+                worker(
+                    partial(
+                        _file_meta_and_size,
+                        filename,
+                        volmin=volmin,
+                        volmax=volmax,
+                    ),
+                    semaphore,
+                )
+            )
+        )
+
+    # Gather guarantees the order of the output
+    metadata, entities, sizes, valid = list(zip(*await asyncio.gather(*tasks)))
+    return metadata, entities, sizes, valid
+
+
+def initialize_meta_and_data(
+    max_concurrent: int = min(cpu_count(), 12),
+) -> None:
+    """
+    Mine data and metadata corresponding to the dataset.
+
+    Get files if datalad enabled and extract the necessary metadata.
+
+    Parameters
+    ----------
+    max_concurrent : :obj:`int`
+        Maximum number of concurrent coroutines (files or multi-echo sets).
+
+    Returns
+    -------
+    :obj:`None`
+
+    """
+    from mriqc import config
+
+    # Datalad-get all files
+    dataset = config.workflow.inputs.values()
+    _datalad_get(dataset)
+
+    # Extract metadata and filesize
+    config.workflow.input_metadata = {}
+    config.workflow.input_entities = {}
+    config.workflow.biggest_file_gb = {}
+    for mod, input_list in config.workflow.inputs.items():
+        config.loggers.cli.log(
+            25,
+            f"Extracting metadata and entities for {len(input_list)} input runs "
+            f"of modality '{mod}'...",
+        )
+
+        # Some modalities require a minimum number of volumes
+        volmin = None
+        if mod == 'bold':
+            volmin = config.workflow.min_len_bold
+        elif mod == 'dwi':
+            volmin = config.workflow.min_len_dwi
+
+        # Some modalities require a maximum number of volumes
+        volmax = None
+        if mod in ('T1w', 'T2w'):
+            volmax = 1
+
+        # Run extraction in a asyncio coroutine loop
+        metadata, entities, size, valid = asyncio.run(
+            _extract_meta_and_size(
+                input_list,
+                max_concurrent=max_concurrent,
+                volmin=volmin,
+                volmax=volmax,
+            )
+        )
+
+        # Identify nonconformant files that need to be dropped (and drop them)
+        if (num_dropped := len(input_list) - np.sum(valid)):
+            config.loggers.workflow.warn(
+                f'{num_dropped} cannot be processed (too short or too long)'
+            )
+
+            filtered_results = [
+                _v[:-1] for _v in zip(input_list, metadata, entities, size, valid)
+                if _v[-1] is True
+            ]
+            input_list, metadata, entities, size = list(zip(*filtered_results))
+            config.workflow.inputs[mod] = input_list
+
+        # Finalizing (write to config so that values are propagated)
+        _max_size = np.max(size)
+        config.workflow.input_metadata[mod] = metadata
+        config.workflow.input_entities[mod] = entities
+        config.workflow.biggest_file_gb[mod] = float(_max_size)  # Cast required to store YAML
+
+        config.loggers.cli.log(
+            25,
+            f"File size ('{mod}'): {_max_size:.2f}|{np.mean(size):.2f} "
+            "GB [maximum|average].",
+        )

--- a/mriqc/workflows/anatomical/base.py
+++ b/mriqc/workflows/anatomical/base.py
@@ -52,6 +52,7 @@ For the skull-stripping, we use ``afni_wf`` from ``niworkflows.anat.skullstrip``
 
 """
 
+from itertools import chain
 from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
 from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
@@ -88,30 +89,43 @@ def anat_qc_workflow(name='anatMRIQC'):
     """
     from mriqc.workflows.shared import synthstrip_wf
 
-    dataset = config.workflow.inputs.get('t1w', []) + config.workflow.inputs.get('t2w', [])
-
+    # Enable if necessary
+    # mem_gb = max(
+    #     config.workflow.biggest_file_gb['t1w'],
+    #     config.workflow.biggest_file_gb['t2w'],
+    # )
+    dataset = list(chain(
+        config.workflow.inputs.get('t1w', []),
+        config.workflow.inputs.get('t2w', []),
+    ))
+    metadata = list(chain(
+        config.workflow.inputs_metadata.get('t1w', []),
+        config.workflow.inputs_metadata.get('t2w', []),
+    ))
+    entities = list(chain(
+        config.workflow.inputs_entities.get('t1w', []),
+        config.workflow.inputs_entities.get('t2w', []),
+    ))
     message = BUILDING_WORKFLOW.format(
         modality='anatomical',
-        detail=(
-            f'for {len(dataset)} NIfTI files.'
-            if len(dataset) > 2
-            else f"({' and '.join('<%s>' % v for v in dataset)})."
-        ),
+        detail=f'for {len(dataset)} NIfTI files.',
     )
     config.loggers.workflow.info(message)
-
-    if config.execution.datalad_get:
-        from mriqc.utils.misc import _datalad_get
-
-        _datalad_get(dataset)
 
     # Initialize workflow
     workflow = pe.Workflow(name=name)
 
     # Define workflow, inputs and outputs
     # 0. Get data
-    inputnode = pe.Node(niu.IdentityInterface(fields=['in_file']), name='inputnode')
-    inputnode.iterables = [('in_file', dataset)]
+    inputnode = pe.Node(niu.IdentityInterface(
+        fields=['in_file', 'metadata', 'entities'],
+    ), name='inputnode')
+    inputnode.synchronize = True  # Do not test combinations of iterables
+    inputnode.iterables = [
+        ('in_file', dataset),
+        ('metadata', metadata),
+        ('entities', entities),
+    ]
 
     outputnode = pe.Node(niu.IdentityInterface(fields=['out_json']), name='outputnode')
 
@@ -146,7 +160,9 @@ def anat_qc_workflow(name='anatMRIQC'):
             ('in_file', 'inputnode.name_source'),
         ]),
         (inputnode, to_ras, [('in_file', 'in_file')]),
-        (inputnode, iqmswf, [('in_file', 'inputnode.in_file')]),
+        (inputnode, iqmswf, [('in_file', 'inputnode.in_file'),
+                             ('metadata', 'inputnode.metadata'),
+                             ('entities', 'inputnode.entities')]),
         (inputnode, norm, [(('in_file', _get_mod), 'inputnode.modality')]),
         (to_ras, skull_stripping, [('out_file', 'inputnode.in_files')]),
         (skull_stripping, hmsk, [
@@ -403,7 +419,6 @@ def compute_iqms(name='ComputeIQMs'):
             wf = compute_iqms()
 
     """
-    from niworkflows.interfaces.bids import ReadSidecarJSON
 
     from mriqc.interfaces.anatomical import Harmonize
     from mriqc.workflows.utils import _tofloat
@@ -413,6 +428,8 @@ def compute_iqms(name='ComputeIQMs'):
         niu.IdentityInterface(
             fields=[
                 'in_file',
+                'metadata',
+                'entities',
                 'in_ras',
                 'brainmask',
                 'airmask',
@@ -424,7 +441,6 @@ def compute_iqms(name='ComputeIQMs'):
                 'inu_corrected',
                 'in_inu',
                 'pvms',
-                'metadata',
                 'std_tpms',
             ]
         ),
@@ -434,9 +450,6 @@ def compute_iqms(name='ComputeIQMs'):
         niu.IdentityInterface(fields=['out_file', 'noisefit']),
         name='outputnode',
     )
-
-    # Extract metadata
-    meta = pe.Node(ReadSidecarJSON(index_db=config.execution.bids_database_dir), name='metadata')
 
     # Add provenance
     addprov = pe.Node(AddProvenance(), name='provenance', run_without_submitting=True)
@@ -472,17 +485,12 @@ def compute_iqms(name='ComputeIQMs'):
 
     # fmt: off
     workflow.connect([
-        (inputnode, meta, [('in_file', 'in_file')]),
-        (inputnode, datasink, [('in_file', 'in_file'),
-                               (('in_file', _get_mod), 'modality')]),
+        (inputnode, datasink, [
+            ('in_file', 'in_file'),
+            (('in_file', _get_mod), 'modality'),
+            ('metadata', 'metadata'),
+            ('entities', 'entities')]),
         (inputnode, addprov, [(('in_file', _get_mod), 'modality')]),
-        (meta, datasink, [('subject', 'subject_id'),
-                          ('session', 'session_id'),
-                          ('task', 'task_id'),
-                          ('acquisition', 'acq_id'),
-                          ('reconstruction', 'rec_id'),
-                          ('run', 'run_id'),
-                          ('out_dict', 'metadata')]),
         (inputnode, addprov, [('in_file', 'in_file'),
                               ('airmask', 'air_msk'),
                               ('rotmask', 'rot_msk')]),

--- a/mriqc/workflows/anatomical/base.py
+++ b/mriqc/workflows/anatomical/base.py
@@ -53,6 +53,7 @@ For the skull-stripping, we use ``afni_wf`` from ``niworkflows.anat.skullstrip``
 """
 
 from itertools import chain
+
 from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
 from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
@@ -94,18 +95,24 @@ def anat_qc_workflow(name='anatMRIQC'):
     #     config.workflow.biggest_file_gb['t1w'],
     #     config.workflow.biggest_file_gb['t2w'],
     # )
-    dataset = list(chain(
-        config.workflow.inputs.get('t1w', []),
-        config.workflow.inputs.get('t2w', []),
-    ))
-    metadata = list(chain(
-        config.workflow.inputs_metadata.get('t1w', []),
-        config.workflow.inputs_metadata.get('t2w', []),
-    ))
-    entities = list(chain(
-        config.workflow.inputs_entities.get('t1w', []),
-        config.workflow.inputs_entities.get('t2w', []),
-    ))
+    dataset = list(
+        chain(
+            config.workflow.inputs.get('t1w', []),
+            config.workflow.inputs.get('t2w', []),
+        )
+    )
+    metadata = list(
+        chain(
+            config.workflow.inputs_metadata.get('t1w', []),
+            config.workflow.inputs_metadata.get('t2w', []),
+        )
+    )
+    entities = list(
+        chain(
+            config.workflow.inputs_entities.get('t1w', []),
+            config.workflow.inputs_entities.get('t2w', []),
+        )
+    )
     message = BUILDING_WORKFLOW.format(
         modality='anatomical',
         detail=f'for {len(dataset)} NIfTI files.',
@@ -117,9 +124,12 @@ def anat_qc_workflow(name='anatMRIQC'):
 
     # Define workflow, inputs and outputs
     # 0. Get data
-    inputnode = pe.Node(niu.IdentityInterface(
-        fields=['in_file', 'metadata', 'entities'],
-    ), name='inputnode')
+    inputnode = pe.Node(
+        niu.IdentityInterface(
+            fields=['in_file', 'metadata', 'entities'],
+        ),
+        name='inputnode',
+    )
     inputnode.synchronize = True  # Do not test combinations of iterables
     inputnode.iterables = [
         ('in_file', dataset),

--- a/mriqc/workflows/diffusion/base.py
+++ b/mriqc/workflows/diffusion/base.py
@@ -98,9 +98,12 @@ def dmri_qc_workflow(name='dwiMRIQC'):
     # Define workflow, inputs and outputs
     # 0. Get data, put it in RAS orientation
     workflow = pe.Workflow(name=name)
-    inputnode = pe.Node(niu.IdentityInterface(
-        fields=['in_file', 'metadata', 'entities'],
-    ), name='inputnode')
+    inputnode = pe.Node(
+        niu.IdentityInterface(
+            fields=['in_file', 'metadata', 'entities'],
+        ),
+        name='inputnode',
+    )
     inputnode.synchronize = True  # Do not test combinations of iterables
     inputnode.iterables = [
         ('in_file', dataset),

--- a/mriqc/workflows/functional/base.py
+++ b/mriqc/workflows/functional/base.py
@@ -43,7 +43,6 @@ The functional workflow follows the following steps:
 This workflow is orchestrated by :py:func:`fmri_qc_workflow`.
 """
 
-
 from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
 from niworkflows.utils.connections import pop_file as _pop
@@ -86,9 +85,12 @@ def fmri_qc_workflow(name='funcMRIQC'):
     # Define workflow, inputs and outputs
     # 0. Get data, put it in RAS orientation
     workflow = pe.Workflow(name=name)
-    inputnode = pe.Node(niu.IdentityInterface(
-        fields=['in_file', 'metadata', 'entities'],
-    ), name='inputnode')
+    inputnode = pe.Node(
+        niu.IdentityInterface(
+            fields=['in_file', 'metadata', 'entities'],
+        ),
+        name='inputnode',
+    )
     inputnode.synchronize = True  # Do not test combinations of iterables
     inputnode.iterables = [
         ('in_file', dataset),

--- a/mriqc/workflows/functional/base.py
+++ b/mriqc/workflows/functional/base.py
@@ -43,9 +43,7 @@ The functional workflow follows the following steps:
 This workflow is orchestrated by :py:func:`fmri_qc_workflow`.
 """
 
-from collections.abc import Iterable
 
-import nibabel as nb
 from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
 from niworkflows.utils.connections import pop_file as _pop
@@ -69,44 +67,38 @@ def fmri_qc_workflow(name='funcMRIQC'):
     """
     from nipype.algorithms.confounds import TSNR, NonSteadyStateDetector
     from nipype.interfaces.afni import TStat
-    from niworkflows.interfaces.bids import ReadSidecarJSON
     from niworkflows.interfaces.header import SanitizeImage
 
     from mriqc.interfaces.functional import SelectEcho
     from mriqc.messages import BUILDING_WORKFLOW
-    from mriqc.utils.misc import _flatten_list as flatten
 
-    workflow = pe.Workflow(name=name)
-
-    mem_gb = config.workflow.biggest_file_gb["bold"]
-
-    dataset = config.workflow.inputs.get('bold', [])
+    mem_gb = config.workflow.biggest_file_gb['bold']
+    dataset = config.workflow.inputs['bold']
+    metadata = config.workflow.inputs_metadata['bold']
+    entities = config.workflow.inputs_entities['bold']
 
     message = BUILDING_WORKFLOW.format(
         modality='functional',
-        detail=(
-            f'for {len(dataset)} BOLD runs.'
-            if len(dataset) > 2
-            else f"({' and '.join('<%s>' % v for v in dataset)})."
-        ),
+        detail=f'for {len(dataset)} BOLD runs.',
     )
     config.loggers.workflow.info(message)
 
     # Define workflow, inputs and outputs
     # 0. Get data, put it in RAS orientation
-    inputnode = pe.Node(niu.IdentityInterface(fields=['in_file']), name='inputnode')
-    inputnode.iterables = [('in_file', dataset)]
+    workflow = pe.Workflow(name=name)
+    inputnode = pe.Node(niu.IdentityInterface(
+        fields=['in_file', 'metadata', 'entities'],
+    ), name='inputnode')
+    inputnode.synchronize = True  # Do not test combinations of iterables
+    inputnode.iterables = [
+        ('in_file', dataset),
+        ('metadata', metadata),
+        ('entities', entities),
+    ]
 
     outputnode = pe.Node(
         niu.IdentityInterface(fields=['qc', 'mosaic', 'out_group', 'out_dvars', 'out_fd']),
         name='outputnode',
-    )
-
-    # Get metadata
-    meta = pe.MapNode(
-        ReadSidecarJSON(index_db=config.execution.bids_database_dir),
-        name='metadata',
-        iterfield=['in_file'],
     )
 
     pick_echo = pe.Node(SelectEcho(), name='pick_echo')
@@ -155,10 +147,9 @@ def fmri_qc_workflow(name='funcMRIQC'):
     # fmt: off
 
     workflow.connect([
-        (inputnode, meta, [('in_file', 'in_file')]),
-        (inputnode, pick_echo, [('in_file', 'in_files')]),
+        (inputnode, pick_echo, [('in_file', 'in_files'),
+                                ('metadata', 'metadata')]),
         (inputnode, sanitize, [('in_file', 'in_file')]),
-        (meta, pick_echo, [('out_dict', 'metadata')]),
         (pick_echo, non_steady_state_detector, [('out_file', 'in_file')]),
         (non_steady_state_detector, sanitize, [('n_volumes_to_discard', 'n_volumes_to_discard')]),
         (sanitize, hmcwf, [('out_file', 'inputnode.in_file')]),
@@ -166,14 +157,9 @@ def fmri_qc_workflow(name='funcMRIQC'):
         (hmcwf, tsnr, [('outputnode.out_file', 'in_file')]),
         (mean, ema, [(('out_file', _pop), 'inputnode.epi_mean')]),
         # Feed IQMs computation
-        (meta, iqmswf, [('out_dict', 'inputnode.metadata'),
-                        ('subject', 'inputnode.subject'),
-                        ('session', 'inputnode.session'),
-                        ('task', 'inputnode.task'),
-                        ('acquisition', 'inputnode.acquisition'),
-                        ('reconstruction', 'inputnode.reconstruction'),
-                        ('run', 'inputnode.run')]),
-        (inputnode, iqmswf, [('in_file', 'inputnode.in_file')]),
+        (inputnode, iqmswf, [('in_file', 'inputnode.in_file'),
+                             ('metadata', 'inputnode.metadata'),
+                             ('entities', 'inputnode.entities')]),
         (sanitize, iqmswf, [('out_file', 'inputnode.in_ras')]),
         (mean, iqmswf, [('out_file', 'inputnode.epi_mean')]),
         (hmcwf, iqmswf, [('outputnode.out_file', 'inputnode.hmc_epi'),
@@ -184,6 +170,7 @@ def fmri_qc_workflow(name='funcMRIQC'):
         # Feed reportlet generation
         (inputnode, func_report_wf, [
             ('in_file', 'inputnode.name_source'),
+            ('metadata', 'inputnode.meta_sidecar'),
         ]),
         (sanitize, func_report_wf, [('out_file', 'inputnode.in_ras')]),
         (mean, func_report_wf, [('out_file', 'inputnode.epi_mean')]),
@@ -201,7 +188,6 @@ def fmri_qc_workflow(name='funcMRIQC'):
             ('outputnode.out_dvars', 'inputnode.in_dvars'),
             ('outputnode.outliers', 'inputnode.outliers'),
         ]),
-        (meta, func_report_wf, [('out_dict', 'inputnode.meta_sidecar')]),
         (hmcwf, outputnode, [('outputnode.out_fd', 'out_fd')]),
     ])
     # fmt: on
@@ -292,13 +278,15 @@ def compute_iqms(name='ComputeIQMs'):
     from mriqc.interfaces.transitional import GCOR
     from mriqc.workflows.utils import _tofloat, get_fwhmx
 
-    mem_gb = config.workflow.biggest_file_gb["bold"]
+    mem_gb = config.workflow.biggest_file_gb['bold']
 
     workflow = pe.Workflow(name=name)
     inputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
                 'in_file',
+                'metadata',
+                'entities',
                 'in_ras',
                 'epi_mean',
                 'brainmask',
@@ -306,15 +294,8 @@ def compute_iqms(name='ComputeIQMs'):
                 'hmc_fd',
                 'fd_thres',
                 'in_tsnr',
-                'metadata',
                 'mpars',
                 'exclude_index',
-                'subject',
-                'session',
-                'task',
-                'acquisition',
-                'reconstruction',
-                'run',
             ]
         ),
         name='inputnode',
@@ -438,12 +419,7 @@ def compute_iqms(name='ComputeIQMs'):
         (inputnode, addprov, [('in_file', 'in_file')]),
         (inputnode, datasink, [('in_file', 'in_file'),
                                ('exclude_index', 'dummy_trs'),
-                               (('subject', _pop), 'subject_id'),
-                               (('session', _pop), 'session_id'),
-                               (('task', _pop), 'task_id'),
-                               (('acquisition', _pop), 'acq_id'),
-                               (('reconstruction', _pop), 'rec_id'),
-                               (('run', _pop), 'run_id'),
+                               ('entities', 'entities'),
                                ('metadata', 'metadata')]),
         (addprov, datasink, [('out_prov', 'provenance')]),
         (outliers, datasink, [(('out_file', _parse_tout), 'aor')]),
@@ -528,7 +504,7 @@ def hmc(name='fMRI_HMC', omp_nthreads=None):
     from nipype.algorithms.confounds import FramewiseDisplacement
     from nipype.interfaces.afni import Despike, Refit, Volreg
 
-    mem_gb = config.workflow.biggest_file_gb["bold"]
+    mem_gb = config.workflow.biggest_file_gb['bold']
 
     workflow = pe.Workflow(name=name)
 

--- a/mriqc/workflows/functional/output.py
+++ b/mriqc/workflows/functional/output.py
@@ -49,7 +49,7 @@ def init_func_report_wf(name='func_report_wf'):
     # from mriqc.interfaces.reports import IndividualReport
 
     verbose = config.execution.verbose_reports
-    mem_gb = config.workflow.biggest_file_gb
+    mem_gb = config.workflow.biggest_file_gb["bold"]
     reportlets_dir = config.execution.work_dir / 'reportlets'
 
     workflow = pe.Workflow(name=name)

--- a/mriqc/workflows/functional/output.py
+++ b/mriqc/workflows/functional/output.py
@@ -49,7 +49,7 @@ def init_func_report_wf(name='func_report_wf'):
     # from mriqc.interfaces.reports import IndividualReport
 
     verbose = config.execution.verbose_reports
-    mem_gb = config.workflow.biggest_file_gb["bold"]
+    mem_gb = config.workflow.biggest_file_gb['bold']
     reportlets_dir = config.execution.work_dir / 'reportlets'
 
     workflow = pe.Workflow(name=name)


### PR DESCRIPTION
Aggregate dataset-wise operations that typically traverse the list of input files (datalad get, extract biggest file size and metadata extraction) in a single step.

Resolves #1316.