### PR TITLE
ENH: Use ``orjson`` to serialize JSON, addressing Numpy serialization issues

### DIFF
--- a/mriqc/interfaces/bids.py
+++ b/mriqc/interfaces/bids.py
@@ -23,7 +23,7 @@
 import re
 from pathlib import Path
 
-import simplejson as json
+import orjson as json
 from nipype.interfaces.base import (
     BaseInterfaceInputSpec,
     DynamicTraitedSpec,
@@ -187,16 +187,15 @@ class IQMFileSink(SimpleInterface):
             self._out_dict['provenance'] = {}
         self._out_dict['provenance'].update(prov_dict)
 
-        with open(out_file, 'w') as f:
-            f.write(
-                json.dumps(
-                    self._out_dict,
-                    sort_keys=True,
-                    indent=2,
-                    ensure_ascii=False,
-                )
-            )
-
+        Path(out_file).write_bytes(json.dumps(
+            self._out_dict,
+            option=(
+                json.OPT_SORT_KEYS
+                | json.OPT_INDENT_2
+                | json.OPT_APPEND_NEWLINE
+                | json.OPT_SERIALIZE_NUMPY
+            ),
+        ))
         return runtime
 
 

--- a/mriqc/interfaces/bids.py
+++ b/mriqc/interfaces/bids.py
@@ -187,15 +187,17 @@ class IQMFileSink(SimpleInterface):
             self._out_dict['provenance'] = {}
         self._out_dict['provenance'].update(prov_dict)
 
-        Path(out_file).write_bytes(json.dumps(
-            self._out_dict,
-            option=(
-                json.OPT_SORT_KEYS
-                | json.OPT_INDENT_2
-                | json.OPT_APPEND_NEWLINE
-                | json.OPT_SERIALIZE_NUMPY
-            ),
-        ))
+        Path(out_file).write_bytes(
+            json.dumps(
+                self._out_dict,
+                option=(
+                    json.OPT_SORT_KEYS
+                    | json.OPT_INDENT_2
+                    | json.OPT_APPEND_NEWLINE
+                    | json.OPT_SERIALIZE_NUMPY
+                ),
+            )
+        )
         return runtime
 
 

--- a/mriqc/interfaces/webapi.py
+++ b/mriqc/interfaces/webapi.py
@@ -155,7 +155,6 @@ class UploadIQMs(SimpleInterface):
             modality=self.inputs.modality,
         )
 
-
         payload_str = orjson.dumps(
             payload,
             option=(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "nitransforms ~= 24.0",
   "niworkflows ~=1.10.1",
   "numpy ~=1.20",
+  "orjson",
   "pandas",
   "pybids >= 0.15.6",
   "PyYAML",


### PR DESCRIPTION
Replaces the standard `json` library with `orjson`, which is way faster
and more reliable in terms of encoding numpy objects (the main issue we
typically hit within *MRIQC*).

Incidentally, this PR fixes an import of `simplejson`, which was not
listed as a dependency.

Related-to: https://github.com/nipreps/mriqc/issues/1302.
Closes: https://github.com/nipreps/mriqc/issues/546.
Closes: https://github.com/nipreps/mriqc/issues/1089.
Closes: https://github.com/nipreps/mriqc/issues/1133.