### PR TITLE
FIX: Passing ``bytes`` into ``str.join()``

### DIFF
--- a/mriqc/interfaces/webapi.py
+++ b/mriqc/interfaces/webapi.py
@@ -191,7 +191,7 @@ class UploadIQMs(SimpleInterface):
                 '',
                 '',
                 'Payload:',
-                payload_str,
+                f'{payload_str}',
             ]
         )
         config.loggers.interface.warning(errmsg)


### PR DESCRIPTION
Introduced-by: #1336.