### PR TITLE
BUG: Fix elapsed runtime format

### DIFF
--- a/mriqc/cli/run.py
+++ b/mriqc/cli/run.py
@@ -23,6 +23,15 @@
 """Definition of the command line interface's (CLI) entry point."""
 
 
+def format_elapsed_time(elapsed_timedelta):
+    """Format a timedelta instance as a %Hh %Mmin %Ss string."""
+    return (
+        f'{elapsed_timedelta.days * 24 + elapsed_timedelta.seconds // 3600:02d}h '
+        f'{(elapsed_timedelta.seconds % 3600) // 60:02d}min '
+        f'{elapsed_timedelta.seconds % 60:02d}s'
+    )
+
+
 def main(argv=None):
     """Entry point for MRIQC's CLI."""
     import atexit
@@ -30,6 +39,7 @@ def main(argv=None):
     import os
     import sys
     import time
+    import datetime
     from tempfile import mkstemp
 
     from mriqc import config, messages
@@ -186,15 +196,15 @@ def main(argv=None):
 
             generate_reports()
 
-        _subject_duration = time.gmtime(
-            (time.time() - config.settings.start_time)
-            / sum(len(files) for files in config.workflow.inputs.values())
+        _subject_duration = (time.time() - config.settings.start_time) / sum(
+            len(files) for files in config.workflow.inputs.values()
         )
+        _subject_duration_td = datetime.timedelta(seconds=_subject_duration)
+        time_strf = format_elapsed_time(_subject_duration_td)
+
         config.loggers.cli.log(
             25,
-            messages.PARTICIPANT_FINISHED.format(
-                duration=time.strftime('%Hh %Mmin %Ss', _subject_duration)
-            ),
+            messages.PARTICIPANT_FINISHED.format(duration=time_strf),
         )
 
         if _resmon is not None:
@@ -258,13 +268,14 @@ def main(argv=None):
     config.loggers.cli.info(messages.BIDS_META)
     write_derivative_description(config.execution.bids_dir, config.execution.output_dir)
     write_bidsignore(config.execution.output_dir)
+
+    _run_duration = time.time() - config.settings.start_time
+    _run_duration_td = datetime.timedelta(seconds=_run_duration)
+    time_strf = format_elapsed_time(_run_duration_td)
+
     config.loggers.cli.log(
         26,
-        messages.RUN_FINISHED.format(
-            duration=time.strftime(
-                '%Hh %Mmin %Ss', time.gmtime(time.time() - config.settings.start_time)
-            )
-        ),
+        messages.RUN_FINISHED.format(duration=time_strf),
     )
     config.to_filename(
         config.execution.log_dir / f'config-{config.execution.run_uuid}.toml',


### PR DESCRIPTION
Fix elapsed runtime format: the `strftime` function `%H` format specifier only supports 0–23 hours (for a single day), thus, when the time exceeds 24 hours, the hours component resets to 0.

This patch set computes the elapsed time (per participant and for the entire run), builds a `datetime.timedelta` instance and formats the elapsed time following the `%Hh %Mmin %Ss` formatting using a function created for that purpose.

Do not call `time.gmtime` as when reporting the elapsed time we are not interested in the UTC time format.