### PR TITLE
ENH: Consider warnings as errors when running `pytest`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,7 @@ version-file = "mriqc/_version.py"
 #
 
 [tool.pytest.ini_options]
-addopts = ["-svx", "--doctest-modules", "-ra", "--strict-config", "--strict-markers"]
+addopts = ["-svx", "--doctest-modules", "-ra", "--strict-config", "--strict-markers", "--strict-warnings"]
 doctest_optionflags = "ALLOW_UNICODE NORMALIZE_WHITESPACE ELLIPSIS"
 env = "PYTHONHASHSEED=0"
 filterwarnings = ["ignore::DeprecationWarning"]


### PR DESCRIPTION
Consider warnings as errors when running `pytest`: add the `strict-warnings` flag to `pytest` to consider warnings as errors.