### PR TITLE
FIX: Decode bytes to produce a string

### DIFF
--- a/mriqc/interfaces/webapi.py
+++ b/mriqc/interfaces/webapi.py
@@ -163,8 +163,8 @@ class UploadIQMs(SimpleInterface):
                 | orjson.OPT_APPEND_NEWLINE
                 | orjson.OPT_SERIALIZE_NUMPY
             ),
-        )
-        Path('payload.json').write_bytes(payload_str)
+        ).decode('utf-8')
+        Path('payload.json').write_text(payload_str)
         self._results['payload_file'] = str(Path('payload.json').absolute())
 
         try:


### PR DESCRIPTION
With the new JSON library, ``dumps()`` seems to return bytes. Here we decode the output of ``dumps()``, ensuring the output is converted into text.
This effectively should address the issue linked below.

Resolves: #1352.