### PR TITLE
ENH: Specify Python version for `ruff`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,7 @@ skip = """
 [tool.ruff]
 exclude = [".maint/update_authors.py"]
 line-length = 99
+target-version = "py310"
 
 [tool.ruff.lint]
 extend-select = [


### PR DESCRIPTION
Specify Python version for `ruff`: use Python 3.10 as a reasonable choice.

Fixes:
```
ruff
The `python-version` input is not set. The version of Python currently in `PATH` will be used.
```

raised for example at:
https://github.com/nipreps/mriqc/actions/runs/12795005155