### PR TITLE
ENH: Remove additional `setup-python` action in GHA workflow file

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -79,8 +79,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
     - run: pipx run ruff format --diff
 
   codespell:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,7 +190,6 @@ skip = """
 [tool.ruff]
 exclude = [".maint/update_authors.py"]
 line-length = 99
-target-version = "py310"
 
 [tool.ruff.lint]
 extend-select = [


### PR DESCRIPTION
Remove additional `setup-python` action in GHA workflow file, as Python is available through `pipx`.

Fixes:
```
ruff
The `python-version` input is not set. The version of Python currently in `PATH` will be used.
```

raised for example at:
https://github.com/nipreps/mriqc/actions/runs/12795005155

Also, revert the change introduced in commit 5cf7010 that unsuccessfully intended to fix the warning.