### PR TITLE
FIX: Ensure conda libstdc++ is preferred at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -176,7 +176,8 @@ ENV PATH="${CONDA_PATH}/bin:$PATH" \
     LD_LIBRARY_PATH="${CONDA_PATH}/lib:$LD_LIBRARY_PATH"
 
 # Refresh linked libraries
-RUN ldconfig
+RUN echo "${CONDA_PATH}/lib" > /etc/ld.so.conf.d/conda.conf \
+    && ldconfig
 # Installing dev requirements (packages that are not in pypi)
 WORKDIR /src/
 # Precaching atlases


### PR DESCRIPTION
### Motivation
- CI jobs running ANTs binaries fail with ``N4BiasFieldCorrection: ... version `GLIBCXX_3.4.32' not found` because the system ``libstdc++`` is picked instead of the newer one bundled in the conda environment.
- Prefer the conda-provided libraries at runtime so ANTs and other conda-installed native binaries resolve against compatible symbols.

### Description
- Update ``Dockerfile`` to write ``${CONDA_PATH}/lib`` into ``/etc/ld.so.conf.d/conda.conf`` and run ``ldconfig`` so the dynamic linker cache prefers the conda library directory at runtime.
- This ensures the conda ``libstdc++`` (and other conda-shipped native libs) are available to executables like ANTs when containers are run.

### Testing
- Ran repository formatter/linter with ``pipx run ruff format --diff`` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977994aa5a0833084d47d923c118793)