### PR TITLE
FIX: Bump MRIQC API tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     environment:
       - TZ: "/usr/share/zoneinfo/America/Los_Angeles"
-      - MRIQC_API_TAG: 1.1.0
+      - MRIQC_API_TAG: 1.1.1
       - MRIQC_API_DOCKER_IMAGES: "nginx:latest swaggerapi/swagger-ui:latest mongo:latest
           python:3.7-slim"
       - DOCKER_BUILDKIT: 1


### PR DESCRIPTION
### Motivation
- Pin the CircleCI `build` job to the newer MRIQC WebAPI patch release so CI uses a known-compatible `1.1.x` API tag.

### Description
- Update `.circleci/config.yml` to change the `MRIQC_API_TAG` environment value from `1.1.0` to `1.1.1`.

### Testing
- Ran lint/format check with `pipx run ruff format --diff`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978b901b6b88330a2366f95ba00e47d)