### PR TITLE
FIX: Remove duplicate IQM parquet writes

### DIFF
--- a/mriqc/interfaces/bids.py
+++ b/mriqc/interfaces/bids.py
@@ -247,29 +247,6 @@ class IQMFileSink(SimpleInterface):
             )
         )
 
-        dataframe = self._build_dataframe()
-        dataframe.to_parquet(parquet_path, index=False)
-
-        sidecar_payload = {
-            'mriqc_version': __version__,
-            'modality': self.inputs.modality,
-            'bids_entities': self._out_dict.get('bids_meta', {}),
-            'columns': [
-                {'name': name, 'dtype': str(dtype)} for name, dtype in dataframe.dtypes.items()
-            ],
-        }
-
-        Path(sidecar_path).write_bytes(
-            json.dumps(
-                sidecar_payload,
-                option=(
-                    json.OPT_SORT_KEYS
-                    | json.OPT_INDENT_2
-                    | json.OPT_APPEND_NEWLINE
-                    | json.OPT_SERIALIZE_NUMPY
-                ),
-            )
-        )
         return runtime
 
 


### PR DESCRIPTION
### Motivation
- Avoid redundant writes of the IQM parquet and sidecar from `IQMFileSink._run_interface` which could lead to inconsistent metadata and unnecessary I/O.
- Simplify the output generation so the IQM dataframe and sidecar are produced once from the `iqm_payload` and `metadata_payload`.

### Description
- Removed the duplicated block that rebuilt the dataframe and rewrote `parquet_path` and `sidecar_path` in `mriqc/interfaces/bids.py`.
- Preserve the single `dataframe = self._build_dataframe(iqm_payload)` flow and its corresponding sidecar write as the sole producer of the IQM parquet and sidecar.
- Retain existing logic for generating `out_file`, `parquet_path`, `sidecar_path`, and writing the `metadata_payload` sidecar.

### Testing
- Ran `pipx run ruff format --diff` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978e982ebd883308f9b9f4a2620fdd0)