### PR TITLE
Force cast of index to integer

### DIFF
--- a/mriqc/interfaces/functional.py
+++ b/mriqc/interfaces/functional.py
@@ -558,7 +558,7 @@ def select_echo(
     if te_echos is not None and len(te_echos) == n_echos:
         try:
             index = np.argmin(np.abs(np.array(te_echos) - te_reference))
-            return in_files[index], index
+            return in_files[index], int(index)
         except TypeError:
             pass
 


### PR DESCRIPTION
Since the upgrade to numpy v2, the doctest for select_echo is failing with the following output:

```
=================================== FAILURES ===================================
______________ [doctest] mriqc.interfaces.functional.select_echo _______________
518 
519     >>> select_echo(["single-echo.nii.gz"])
520     ('single-echo.nii.gz', -1)
521 
522     >>> select_echo(
523     ...     [f"echo{n}.nii.gz" for n in range(1,7)],
524     ... )
525     ('echo2.nii.gz', 1)
526 
527     >>> select_echo(
Expected:
    ('echo3.nii.gz', 2)
Got:
    ('echo3.nii.gz', np.int64(2))
```

An explicit cast should get rid of it.